### PR TITLE
Improve find docker image uses recipe

### DIFF
--- a/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
@@ -57,18 +57,18 @@ public class DockerfileImageReference implements Reference {
                     .split("\\s+");
 
             Set<Reference> references = new HashSet<>();
-            ArrayList<String> imageVariables = new ArrayList<>();
+            ArrayList<String> aliases = new ArrayList<>();
             for (int i = 0, wordsLength = words.length; i < wordsLength; i++) {
                 if ("from".equalsIgnoreCase(words[i])) {
                     String image = words[i + 1].startsWith("--platform") ? words[i + 2] : words[i + 1];
-                    if (!imageVariables.contains(image)) {
+                    if (!aliases.contains(image)) {
                         references.add(new DockerfileImageReference(c, image));
                     }
                 } else if ("as".equalsIgnoreCase(words[i])) {
-                    imageVariables.add(words[i + 1]);
+                    aliases.add(words[i + 1]);
                 } else if (words[i].startsWith("--from") && words[i].split("=").length == 2) {
                     String image = words[i].split("=")[1];
-                    if (!imageVariables.contains(image) && !StringUtils.isNumeric(image)) {
+                    if (!aliases.contains(image) && !StringUtils.isNumeric(image)) {
                         references.add(new DockerfileImageReference(c, image));
                     }
                 }

--- a/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
@@ -52,8 +52,8 @@ public class DockerfileImageReference implements Reference {
         public Set<Reference> getReferences(SourceFile sourceFile) {
             Cursor c = new Cursor(new Cursor(null, Cursor.ROOT_VALUE), sourceFile);
             String[] words = ((PlainText) sourceFile).getText()
-                    .replaceAll("\\s*#.*?\\n", "") // remove comments
-                    .replaceAll("\".*?\"", "") // remove string literals
+                    .replaceAll("\\s*#.*?\\n", " ") // remove comments
+                    .replaceAll("\".*?\"", " ") // remove string literals
                     .split("\\s+");
 
             Set<Reference> references = new HashSet<>();
@@ -61,7 +61,9 @@ public class DockerfileImageReference implements Reference {
             for (int i = 0, wordsLength = words.length; i < wordsLength; i++) {
                 if ("from".equalsIgnoreCase(words[i])) {
                     String image = words[i + 1].startsWith("--platform") ? words[i + 2] : words[i + 1];
-                    references.add(new DockerfileImageReference(c, image));
+                    if (!imageVariables.contains(image)) {
+                        references.add(new DockerfileImageReference(c, image));
+                    }
                 } else if ("as".equalsIgnoreCase(words[i])) {
                     imageVariables.add(words[i + 1]);
                 } else if (words[i].startsWith("--from") && words[i].split("=").length == 2) {

--- a/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
+++ b/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
@@ -97,18 +97,18 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM golang:1.7.3 as builder
-              # another from to prove aliases can be used
-              FROM builder
+              FROM golang:1.7.3 AS builder
+              # another FROM to prove aliases can be used
+              FROM builder AS stage1
               WORKDIR /go/src/github.com/alexellis/href-counter/
               RUN go get -d -v golang.org/x/net/html
               COPY app.go .
               RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
               """,
             """
-              FROM ~~(golang:1.7.3)~~>golang:1.7.3 as builder
-              # another from to prove aliases can be used
-              FROM builder
+              FROM ~~(golang:1.7.3)~~>golang:1.7.3 AS builder
+              # another FROM to prove aliases can be used
+              FROM builder AS stage1
               WORKDIR /go/src/github.com/alexellis/href-counter/
               RUN go get -d -v golang.org/x/net/html
               COPY app.go .

--- a/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
+++ b/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
@@ -98,6 +98,8 @@ class FindDockerImagesUsedTest implements RewriteTest {
             //language=Dockerfile
             """
               FROM golang:1.7.3 as builder
+              # another from to prove aliases can be used
+              FROM builder
               WORKDIR /go/src/github.com/alexellis/href-counter/
               RUN go get -d -v golang.org/x/net/html
               COPY app.go .
@@ -105,6 +107,8 @@ class FindDockerImagesUsedTest implements RewriteTest {
               """,
             """
               FROM ~~(golang:1.7.3)~~>golang:1.7.3 as builder
+              # another from to prove aliases can be used
+              FROM builder
               WORKDIR /go/src/github.com/alexellis/href-counter/
               RUN go get -d -v golang.org/x/net/html
               COPY app.go .
@@ -255,16 +259,20 @@ class FindDockerImagesUsedTest implements RewriteTest {
     @Test
     void dockerFileIgnoreComment() {
         rewriteRun(
-          assertImages("alpine:latest"),
+          assertImages("alpine:latest", "eclipse-temurin:17-jammy"),
           text(
             //language=Dockerfile
             """
               # FROM alpine
               FROM alpine:latest
+              # more comments
+              FROM eclipse-temurin:17-jammy
               """,
             """
               # FROM alpine
               FROM ~~(alpine:latest)~~>alpine:latest
+              # more comments
+              FROM ~~(eclipse-temurin:17-jammy)~~>eclipse-temurin:17-jammy
               """,
             spec -> spec.path("Dockerfile")
           )


### PR DESCRIPTION
## What's changed?
- Better support for comments
- Better support for aliases

## What's your motivation - Comments?
```dockerfile
FROM eclipse-temurin:17-jammy AS jdk17

# Install dependencies
FROM jdk17 AS dependencies
```

was translated to 

```dockerfile
FROM eclipse-temurin:17-jammy AS jdk17FROM jdk17 AS dependencies
```

before parsing.

## What's your motivation - Aliases?
Using [aliases](https://docs.docker.com/build/building/multi-stage/#differences-between-legacy-builder-and-buildkit) in the FROM did not work as well:

```dockerfile
FROM ubuntu AS base
RUN echo "base" 

FROM base AS stage1
RUN echo "stage1"
```


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
