### PR TITLE
Support Dockerfile withs prefixes and suffixes

### DIFF
--- a/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
@@ -25,6 +25,9 @@ import org.openrewrite.trait.Reference;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 @Value
 public class DockerfileImageReference implements Reference {
@@ -37,13 +40,17 @@ public class DockerfileImageReference implements Reference {
     }
 
     public static class Provider implements Reference.Provider {
+        public static final Pattern DOCKER = Pattern.compile("dockerfile", CASE_INSENSITIVE);
+        public static final Pattern CONTAINER = Pattern.compile("containerfile", CASE_INSENSITIVE);
+        public static final Pattern FROM = Pattern.compile("from", CASE_INSENSITIVE);
+
         @Override
         public boolean isAcceptable(SourceFile sourceFile) {
             if (sourceFile instanceof PlainText) {
                 PlainText text = (PlainText) sourceFile;
                 String fileName = text.getSourcePath().toFile().getName();
-                return (fileName.endsWith("Dockerfile") || fileName.equals("Containerfile")) &&
-                        (text.getText().contains("FROM") || text.getText().contains("from"));
+                ;
+                return (DOCKER.matcher(fileName).find() || CONTAINER.matcher(fileName).find()) && FROM.matcher(text.getText()).find();
             }
             return false;
         }

--- a/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
+++ b/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
@@ -279,6 +279,32 @@ class FindDockerImagesUsedTest implements RewriteTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"aarch64-dockerfile", "Dockerfile.aarch64"})
+    void dockerFileWithSuffixOrPrefix(String fileName) {
+        rewriteRun(
+          assertImages("ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"),
+          text(
+            //language=Dockerfile
+            """
+              FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+
+              RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
+              RUN dpkg --add-architecture arm64
+              RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
+              """,
+            """
+              FROM ~~(ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main)~~>ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+
+              RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
+              RUN dpkg --add-architecture arm64
+              RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
+              """,
+            spec -> spec.path(fileName)
+          )
+        );
+    }
+
     @Test
     void gitlabCIFile() {
         rewriteRun(


### PR DESCRIPTION

## What's changed?
A dockerfile are called "Dockerfile" by convention, but can be [named](https://docs.docker.com/build/concepts/dockerfile/#filename) anything. I added support for prefixes ans suffix, so we can at least parse [Dockerfile.aarch64](https://github.com/Netflix/bpftop/blob/101ac37c7d231af688b0c6da39fa07fc90febc92/dockerfiles/Dockerfile.aarch64) for example.

## What's your motivation?
More images in dockerfiles can be found.

## Any additional context
We could also go another/better way, by expanding the recipe with name patterns. I choose to write this quick fix, if we want to do this, I would propose another PR.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
