### PR TITLE
feat: contribute jimschubert/rewrite-docker to official repo

### DIFF
--- a/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
+++ b/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
@@ -52,17 +52,23 @@ public class AddOrUpdateDirective extends ScanningRecipe<AddOrUpdateDirective.Sc
     }
 
     @Override
+    public Validated<Object> validate(ExecutionContext ctx) {
+        Validated<Object> validated = super.validate();
+
+        if (!directive.matches("^(?i)(syntax|escape|check)\\s*=.+$")) {
+            return validated
+                    .and(Validated.invalid("directive", directive,
+                            "Directive key must be one of: syntax, escape, check."));
+        }
+
+        return validated;
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
         String[] parts = directive.split("=", 2);
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Directive must be in the format key=value");
-        }
 
         String key = parts[0];
-        if (!key.matches("^(?i)(syntax|escape|check)$")) {
-            throw new IllegalArgumentException("Directive must be one of: syntax, escape, check");
-        }
-
         String value = parts[1];
 
         acc.targetKey = key;

--- a/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
+++ b/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
+++ b/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.SearchResult;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class AddOrUpdateDirective extends ScanningRecipe<AddOrUpdateDirective.Scanned> {
+    @Option(displayName = "The full directive",
+            description = "The full directive without leading comment. One of: syntax, escape, check.",
+            example = "check=skip=JSONArgsRecommended;error=true")
+    String directive;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Add or update directive";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Add a directive or update an existing directive.";
+    }
+
+    @Override
+    public Scanned getInitialValue(ExecutionContext ctx) {
+        Scanned scanned = new Scanned();
+        scanned.hasDirective = false;
+        scanned.requiresUpdate = true;
+        return scanned;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
+        if (directive == null) {
+            throw new IllegalArgumentException("Directive is required");
+        }
+
+        String[] parts = directive.split("=", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Directive must be in the format key=value");
+        }
+
+        String key = parts[0];
+        if (!key.matches("^(?i)(syntax|escape|check)$")) {
+            throw new IllegalArgumentException("Directive must be one of: syntax, escape, check");
+        }
+
+        String value = parts[1];
+
+        acc.targetKey = key;
+        acc.targetValue = value;
+
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
+                dockerfile = super.visitDocument(dockerfile, ctx);
+                Docker.Document d = dockerfile;
+                if (acc.requiresUpdate) {
+                    return SearchResult.found(d);
+                }
+                return d;
+            }
+
+            @Override
+            public Docker.Directive visitDirective(Docker.Directive directive, ExecutionContext ctx) {
+                directive = super.visitDirective(directive, ctx);
+                Docker.Directive d = directive;
+                if (d.getKey().equalsIgnoreCase(key)) {
+                    acc.hasDirective = true;
+                    if (d.getValue().trim().equals(value.trim())) {
+                        acc.requiresUpdate = false;
+                    } else {
+                        return SearchResult.found(d);
+                    }
+                }
+
+                return d;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        return Preconditions.check(acc.requiresUpdate, new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
+                dockerfile = super.visitDocument(dockerfile, ctx); // visit to hit the directive case
+
+                if (!acc.hasDirective) {
+                    dockerfile = dockerfile.withStages(
+                            ListUtils.mapFirst(dockerfile.getStages(), stage ->
+                            {
+                                if (stage == null) {
+                                    return null;
+                                }
+
+                                return stage.withChildren(ListUtils.insert(stage.getChildren(), Docker.Directive.build(acc.targetKey, acc.targetValue), 0));
+                            }));
+                }
+                return dockerfile;
+            }
+
+            @Override
+            public Docker.Directive visitDirective(Docker.Directive directive, ExecutionContext ctx) {
+                if (acc.requiresUpdate && directive.getKey().equalsIgnoreCase(acc.targetKey)) {
+                    acc.requiresUpdate = false;
+                    return directive.withKey(acc.targetKey).withValue(acc.targetValue).withMarkers(directive.getMarkers());
+                }
+                return directive;
+            }
+        });
+    }
+
+    public static class Scanned {
+        boolean requiresUpdate;
+        boolean hasDirective;
+        String targetKey;
+        String targetValue;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
+++ b/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.SearchResult;
 
@@ -72,7 +72,7 @@ public class AddOrUpdateDirective extends ScanningRecipe<AddOrUpdateDirective.Sc
         acc.targetKey = key;
         acc.targetValue = value;
 
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
                 dockerfile = super.visitDocument(dockerfile, ctx);
@@ -103,7 +103,7 @@ public class AddOrUpdateDirective extends ScanningRecipe<AddOrUpdateDirective.Sc
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
-        return Preconditions.check(acc.requiresUpdate, new DockerIsoVisitor<>() {
+        return Preconditions.check(acc.requiresUpdate, new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
                 dockerfile = super.visitDocument(dockerfile, ctx); // visit to hit the directive case

--- a/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
+++ b/src/main/java/org/openrewrite/docker/AddOrUpdateDirective.java
@@ -53,10 +53,6 @@ public class AddOrUpdateDirective extends ScanningRecipe<AddOrUpdateDirective.Sc
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
-        if (directive == null) {
-            throw new IllegalArgumentException("Directive is required");
-        }
-
         String[] parts = directive.split("=", 2);
         if (parts.length != 2) {
             throw new IllegalArgumentException("Directive must be in the format key=value");

--- a/src/main/java/org/openrewrite/docker/AsDockerfile.java
+++ b/src/main/java/org/openrewrite/docker/AsDockerfile.java
@@ -14,7 +14,6 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ import lombok.Value;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
@@ -42,6 +42,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @NoArgsConstructor(force = true)
 public class AsDockerfile extends Recipe {
+    @Nullable
     @Option(displayName = "File pattern",
             description = "A file path glob expression to match from the project root. Blank/null matches all." +
                           "Supports multiple patterns separated by a semicolon `;`.",
@@ -61,7 +62,7 @@ public class AsDockerfile extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        PlainTextVisitor<ExecutionContext> visitor = new PlainTextVisitor<>() {
+        PlainTextVisitor<ExecutionContext> visitor = new PlainTextVisitor<ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, @NonNull ExecutionContext executionContext) {
                 Optional<SourceFile> maybeDockerfile = Optional.empty();

--- a/src/main/java/org/openrewrite/docker/AsDockerfile.java
+++ b/src/main/java/org/openrewrite/docker/AsDockerfile.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/AsDockerfile.java
+++ b/src/main/java/org/openrewrite/docker/AsDockerfile.java
@@ -77,7 +77,7 @@ public class AsDockerfile extends Recipe {
                 // this instanceof is required because rewrite may expose an error as a
                 // org.openrewrite.tree.ParseError which extends SourceFile.
                 if (maybeDockerfile.isPresent() && maybeDockerfile.get() instanceof Docker.Document) {
-                    SourceFile input = (SourceFile)tree;
+                    SourceFile input = (SourceFile) tree;
                     Docker.Document dockerfile = (Docker.Document) maybeDockerfile.get();
                     return dockerfile
                             .withId(input.getId())

--- a/src/main/java/org/openrewrite/docker/AsDockerfile.java
+++ b/src/main/java/org/openrewrite/docker/AsDockerfile.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.quark.Quark;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+import java.util.Optional;
+
+/**
+ * Treat a file as a Dockerfile. This is useful for files which don't follow a conventional naming standard.
+ * <p>
+ * For example, if you have a file named "Dockerfile.dev" and you want to treat it as a Dockerfile, you can use this recipe.
+ * <p>
+ * <p>
+ * The idea for this recipe came from a discussion on the OpenRewrite Slack channel, where it was suggested to
+ * <a href="https://github.com/openrewrite/rewrite/pull/3993#issuecomment-2227376531">force load via recipe</a>.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class AsDockerfile extends Recipe {
+    @Option(displayName = "File pattern",
+            description = "A file path glob expression to match from the project root. Blank/null matches all." +
+                          "Supports multiple patterns separated by a semicolon `;`.",
+            required = false,
+            example = ".github/workflows/*.yml")
+    String filePattern;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Treat a file as a Dockerfile";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Treat a file as a Dockerfile. This is useful for files which don't follow a conventional naming standard.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        PlainTextVisitor<ExecutionContext> visitor = new PlainTextVisitor<>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, @NonNull ExecutionContext executionContext) {
+                Optional<SourceFile> maybeDockerfile = Optional.empty();
+                if (tree instanceof PlainText) {
+                    PlainText plainText = (PlainText) tree;
+                    maybeDockerfile = DockerParser.builder().build().parse(plainText.print(getCursor())).findFirst();
+                } else if (tree instanceof Quark) {
+                    Quark quark = (Quark) tree;
+                    maybeDockerfile = DockerParser.builder().build().parse(quark.print(getCursor())).findFirst();
+                }
+
+                // this instanceof is required because rewrite may expose an error as a
+                // org.openrewrite.tree.ParseError which extends SourceFile.
+                if (maybeDockerfile.isPresent() && maybeDockerfile.get() instanceof Docker.Document) {
+                    SourceFile input = (SourceFile)tree;
+                    Docker.Document dockerfile = (Docker.Document) maybeDockerfile.get();
+                    return dockerfile
+                            .withId(input.getId())
+                            .withCharset(input.getCharset())
+                            .withSourcePath(input.getSourcePath())
+                            .withFileAttributes(input.getFileAttributes())
+                            .withChecksum(input.getChecksum())
+                            .withCharsetBomMarked(input.isCharsetBomMarked())
+                            .withMarkers(input.getMarkers());
+                }
+
+                return super.visit(tree, executionContext);
+            }
+        };
+
+        return Preconditions.check(new FindSourceFiles(filePattern), visitor);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/ChangeImage.java
+++ b/src/main/java/org/openrewrite/docker/ChangeImage.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class ChangeImage extends Recipe {
+
+    @Option(displayName = "Match image",
+            description = "A regular expression to locate an image entry.",
+            example = ".*/ubuntu/.*")
+    String matchImage;
+
+    @Option(displayName = "New image",
+            description = "The new image for the image found by `oldImage`. Can be format `registry/image`, `image`, `image:tag`, etc.",
+            example = "alpine")
+    String newImage;
+
+    @Nullable
+    @Option(displayName = "New version",
+            description = "The new version (tag or digest) for the image found by `oldImage`. Can be format `:tagName`, `@digest`, or `tagName`. " +
+                          "If not provided, the version will be left as-is. " +
+                          "To unset a tag, newImage must not contain a tag, and newVersion must be set to an empty string.",
+            example = ":latest",
+            required = false)
+    String newVersion;
+
+    @Nullable
+    @Option(displayName = "New platform",
+            description = "The new platform for the image found by `matchImage`. Can be full format " +
+                          "(`--platform=linux/amd64`), partial (`linux/amd64`)" +
+                          "If not provided, the platform will be left as-is. " +
+                          "To unset a platform, newPlatform must be set to an empty string.",
+            example = "--platform=linux/amd64",
+            required = false)
+    String newPlatform;
+
+    @Override
+    public String getDisplayName() {
+        return "Change a docker image name";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change a docker image name in a FROM instruction.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
+                if (matchImage == null || newImage == null) {
+                    return from;
+                }
+
+                Matcher matcher = Pattern.compile(matchImage).matcher(from.getImageSpecWithVersion());
+                if (matcher.matches()) {
+                    String version = newVersion;
+                    String image = null;
+                    String platform = null;
+
+                    // if newImage contains tag, we need to replace it via withTag, else with '@' digest we replace via withDigest
+                    if (newImage.contains("@")) {
+                        String[] parts = newImage.split("@");
+                        image = parts[0];
+                        if (parts.length > 1) {
+                            version = parts[1];
+                        }
+                    } else if (newImage.contains(":")) {
+                        String[] parts = newImage.split(":");
+                        image = parts[0];
+                        if (parts.length > 1) {
+                            version = parts[1];
+                        }
+                    } else {
+                        image = newImage;
+                    }
+
+                    if (newPlatform != null) {
+                        platform = newPlatform;
+                    } else {
+                        platform = from.getPlatform().getText();
+                    }
+
+                    if (image != null && !image.equals(from.getImage().getText())) {
+                        from = from.image(image);
+                    }
+
+                    if (version != null && !version.equals(from.getVersion().getText())) {
+                        from = from.version(version);
+                    }
+
+                    if (platform != null && !platform.equals(from.getPlatform().getText())) {
+                        from = from.platform(platform);
+                    }
+
+                    return super.visitFrom(from, executionContext);
+                }
+
+                return from;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/docker/ChangeImage.java
+++ b/src/main/java/org/openrewrite/docker/ChangeImage.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/ChangeImage.java
+++ b/src/main/java/org/openrewrite/docker/ChangeImage.java
@@ -14,7 +14,6 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +23,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.tree.Docker;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -75,7 +75,7 @@ public class ChangeImage extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
                 if (matchImage == null || newImage == null) {

--- a/src/main/java/org/openrewrite/docker/DockerIsoVisitor.java
+++ b/src/main/java/org/openrewrite/docker/DockerIsoVisitor.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/DockerIsoVisitor.java
+++ b/src/main/java/org/openrewrite/docker/DockerIsoVisitor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+
+/**
+ * An isomorphic visitor for Dockerfile ASTs.
+ * Each visit method returns the same type as the input, but with the children visited.
+ * This visitor should be preferred over {@link DockerVisitor} when visiting the Dockerfile LST.
+ *
+ * @param <T>
+ * @see <a href="https://docs.openrewrite.org/concepts-and-explanations/visitors#isomorphic-vs-non-isomorphic-visitors">OpenRewrite docs: Visitor</a>
+ */
+public class DockerIsoVisitor<T> extends DockerVisitor<T> {
+    @Override
+    public Docker.Document visitDocument(Docker.Document dockerfile, T ctx) {
+        return (Docker.Document) super.visitDocument(dockerfile, ctx);
+    }
+
+    @Override
+    public Space visitSpace(Space space, T t) {
+        return super.visitSpace(space, t);
+    }
+
+    @Override
+    public Docker.Stage visitStage(Docker.Stage stage, T t) {
+        return (Docker.Stage) super.visitStage(stage, t);
+    }
+
+    @Override
+    public Docker.From visitFrom(Docker.From from, T t) {
+        return (Docker.From) super.visitFrom(from, t);
+    }
+
+    @Override
+    public Docker.Comment visitComment(Docker.Comment comment, T t) {
+        return (Docker.Comment) super.visitComment(comment, t);
+    }
+
+    @Override
+    public Docker.Directive visitDirective(Docker.Directive directive, T t) {
+        return (Docker.Directive) super.visitDirective(directive, t);
+    }
+
+    @Override
+    public Docker.Run visitRun(Docker.Run run, T t) {
+        return (Docker.Run) super.visitRun(run, t);
+    }
+
+    @Override
+    public Docker.Cmd visitCmd(Docker.Cmd cmd, T t) {
+        return (Docker.Cmd) super.visitCmd(cmd, t);
+    }
+
+    @Override
+    public Docker.Label visitLabel(Docker.Label label, T t) {
+        return (Docker.Label) super.visitLabel(label, t);
+    }
+
+    @Override
+    public Docker.Maintainer visitMaintainer(Docker.Maintainer maintainer, T t) {
+        return (Docker.Maintainer) super.visitMaintainer(maintainer, t);
+    }
+
+    @Override
+    public Docker.Expose visitExpose(Docker.Expose expose, T t) {
+        return (Docker.Expose) super.visitExpose(expose, t);
+    }
+
+    @Override
+    public Docker.Env visitEnv(Docker.Env env, T t) {
+        return (Docker.Env) super.visitEnv(env, t);
+    }
+
+    @Override
+    public Docker.Add visitAdd(Docker.Add add, T t) {
+        return (Docker.Add) super.visitAdd(add, t);
+    }
+
+    @Override
+    public Docker.Copy visitCopy(Docker.Copy copy, T t) {
+        return (Docker.Copy) super.visitCopy(copy, t);
+    }
+
+    @Override
+    public Docker.Entrypoint visitEntrypoint(Docker.Entrypoint entrypoint, T t) {
+        return (Docker.Entrypoint) super.visitEntrypoint(entrypoint, t);
+    }
+
+    @Override
+    public Docker.Volume visitVolume(Docker.Volume volume, T t) {
+        return (Docker.Volume) super.visitVolume(volume, t);
+    }
+
+    @Override
+    public Docker.User visitUser(Docker.User user, T t) {
+        return (Docker.User) super.visitUser(user, t);
+    }
+
+    @Override
+    public Docker.Workdir visitWorkdir(Docker.Workdir workdir, T t) {
+        return (Docker.Workdir) super.visitWorkdir(workdir, t);
+    }
+
+    @Override
+    public Docker.Arg visitArg(Docker.Arg arg, T t) {
+        return (Docker.Arg) super.visitArg(arg, t);
+    }
+
+    @Override
+    public Docker.OnBuild visitOnBuild(Docker.OnBuild onBuild, T t) {
+        return (Docker.OnBuild) super.visitOnBuild(onBuild, t);
+    }
+
+    @Override
+    public Docker.StopSignal visitStopSignal(Docker.StopSignal stopSignal, T t) {
+        return (Docker.StopSignal) super.visitStopSignal(stopSignal, t);
+    }
+
+    @Override
+    public Docker.Healthcheck visitHealthcheck(Docker.Healthcheck healthcheck, T t) {
+        return (Docker.Healthcheck) super.visitHealthcheck(healthcheck, t);
+    }
+
+    @Override
+    public Docker.Shell visitShell(Docker.Shell shell, T t) {
+        return (Docker.Shell) super.visitShell(shell, t);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/DockerParser.java
+++ b/src/main/java/org/openrewrite/docker/DockerParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.internal.DockerfileParser;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.EncodingDetectingInputStream;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.tree.ParseError;
+import org.openrewrite.tree.ParsingEventListener;
+import org.openrewrite.tree.ParsingExecutionContextView;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class DockerParser implements Parser {
+    @Override
+    public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
+        return acceptedInputs(sources).map(input -> {
+            parsingListener.startedParsing(input);
+            try (EncodingDetectingInputStream is = input.getSource(ctx)) {
+                DockerfileParser parser = new DockerfileParser();
+
+                Docker.Document document = parser.parse(is)
+                        .withFileAttributes(input.getFileAttributes())
+                        .withSourcePath(input.getPath());
+
+                parsingListener.parsed(input, document);
+
+                return requirePrintEqualsInput(
+                        document.withCharset(is.getCharset()),
+                        input,
+                        relativeTo,
+                        ctx);
+            } catch (Throwable t) {
+                ctx.getOnError().accept(t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
+            }
+        });
+    }
+
+    @Override
+    public boolean accept(Path path) {
+        String fileName = path.toString();
+        return fileName.endsWith(".dockerfile") || fileName.equalsIgnoreCase("dockerfile") ||
+               fileName.endsWith(".containerfile") || fileName.equalsIgnoreCase("containerfile");
+    }
+
+    @Override
+    public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
+        return prefix.resolve("Dockerfile");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends Parser.Builder {
+        public Builder() {
+            super(Docker.Document.class);
+        }
+
+        @Override
+        public DockerParser build() {
+            return new DockerParser();
+        }
+
+        @Override
+        public String getDslName() {
+            return "dockerfile";
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/docker/DockerParser.java
+++ b/src/main/java/org/openrewrite/docker/DockerParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/DockerParser.java
+++ b/src/main/java/org/openrewrite/docker/DockerParser.java
@@ -14,13 +14,13 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.internal.DockerfileParser;
-import org.openrewrite.docker.tree.Docker;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
+import org.openrewrite.docker.internal.DockerfileParser;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.EncodingDetectingInputStream;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;

--- a/src/main/java/org/openrewrite/docker/DockerParsingException.java
+++ b/src/main/java/org/openrewrite/docker/DockerParsingException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import java.nio.file.Path;
+
+public class DockerParsingException extends Exception {
+    private final Path sourcePath;
+
+    public DockerParsingException(Path sourcePath, String message, Throwable t) {
+        super(message, t);
+        this.sourcePath = sourcePath;
+    }
+
+    public Path getSourcePath() {
+        return sourcePath;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/DockerParsingException.java
+++ b/src/main/java/org/openrewrite/docker/DockerParsingException.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/DockerVisitor.java
+++ b/src/main/java/org/openrewrite/docker/DockerVisitor.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Markers;
+
+/**
+ * A visitor for Docker LSTs.
+ * Each visit method returns an abstract type. This visitor allows for rewriting the Dockerfile (e.g. replace an ARG instruction with an ENV instruction).
+ * For the most part, you'll want to use {@link DockerIsoVisitor} when visiting the Dockerfile AST.
+ *
+ * @param <P>
+ * @see <a href="https://docs.openrewrite.org/concepts-and-explanations/visitors#isomorphic-vs-non-isomorphic-visitors">OpenRewrite docs: Visitor</a>
+ */
+public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
+    @Override
+    public @Nullable String getLanguage() {
+        return "Dockerfile";
+    }
+
+    public Docker visitDocument(Docker.Document dockerfile, P ctx) {
+        return dockerfile.withStages(ListUtils.map(dockerfile.getStages(), s -> visitAndCast(s, ctx)))
+                .withMarkers(visitMarkers(dockerfile.getMarkers(), ctx));
+    }
+
+    public Space visitSpace(Space space, P p) {
+        return space;
+    }
+
+    public Docker visitStage(Docker.Stage stage, P p) {
+        return stage.withChildren(ListUtils.map(stage.getChildren(), c -> visitAndCast(c, p)))
+                .withMarkers(visitMarkers(stage.getMarkers(), p));
+    }
+
+    public Docker visitFrom(Docker.From from, P p) {
+        return from.withPrefix(visitSpace(from.getPrefix(), p))
+                .withImage(visitAndCast(from.getImage(), p))
+                .withPlatform(visitAndCast(from.getPlatform(), p))
+                .withVersion(visitAndCast(from.getVersion(), p))
+                .withAs(visitAndCast(from.getAs(), p))
+                .withAlias(visitAndCast(from.getAlias(), p))
+                .withMarkers(visitMarkers(from.getMarkers(), p));
+    }
+
+    public Docker visitComment(Docker.Comment comment, P p) {
+        return comment.withPrefix(visitSpace(comment.getPrefix(), p))
+                .withText(comment.getText()) // Assuming the text doesn't need visiting
+                .withMarkers(visitMarkers(comment.getMarkers(), p));
+    }
+
+    public Docker visitRun(Docker.Run run, P p) {
+        return run
+                .withPrefix(visitSpace(run.getPrefix(), p))
+                .withOptions(ListUtils.map(run.getOptions(), o -> visitAndCast(o, p)))
+                .withCommands(ListUtils.map(run.getCommands(), c -> visitAndCast(c, p)))
+                .withMarkers(visitMarkers(run.getMarkers(), p));
+    }
+
+    public Docker visitCmd(Docker.Cmd cmd, P p) {
+        return cmd
+                .withForm(cmd.getForm())
+                .withPrefix(visitSpace(cmd.getPrefix(), p))
+                .withExecFormPrefix(visitSpace(cmd.getExecFormPrefix(), p))
+                .withCommands(ListUtils.map(cmd.getCommands(), c -> visitAndCast(c, p)))
+                .withExecFormSuffix(visitSpace(cmd.getExecFormSuffix(), p))
+                .withMarkers(visitMarkers(cmd.getMarkers(), p));
+    }
+
+    public Docker visitLabel(Docker.Label label, P p) {
+        return label
+                .withPrefix(visitSpace(label.getPrefix(), p))
+                .withArgs(ListUtils.map(label.getArgs(), a -> visitDockerRightPadded(a, p)))
+                .withMarkers(visitMarkers(label.getMarkers(), p));
+    }
+
+    public Docker visitMaintainer(Docker.Maintainer maintainer, P p) {
+        return maintainer
+                .withQuoting(maintainer.getQuoting()) // Assuming quoting doesn't need visiting
+                .withPrefix(visitSpace(maintainer.getPrefix(), p))
+                .withName(visitAndCast(maintainer.getName(), p))
+                .withMarkers(visitMarkers(maintainer.getMarkers(), p));
+    }
+
+    public Docker visitExpose(Docker.Expose expose, P p) {
+        return expose
+                .withPrefix(visitSpace(expose.getPrefix(), p))
+                .withPorts(ListUtils.map(expose.getPorts(), port -> visitDockerRightPadded(port, p)))
+                .withMarkers(visitMarkers(expose.getMarkers(), p));
+    }
+
+    public Docker visitEnv(Docker.Env env, P p) {
+        return env
+                .withPrefix(visitSpace(env.getPrefix(), p))
+                .withArgs(ListUtils.map(env.getArgs(), a -> visitDockerRightPadded(a, p)))
+                .withMarkers(visitMarkers(env.getMarkers(), p));
+    }
+
+    public Docker visitAdd(Docker.Add add, P p) {
+        return add
+                .withPrefix(visitSpace(add.getPrefix(), p))
+                .withOptions(ListUtils.map(add.getOptions(), o -> visitAndCast(o, p)))
+                .withSources(ListUtils.map(add.getSources(), s -> visitAndCast(s, p)))
+                .withDestination(visitAndCast(add.getDestination(), p))
+                .withMarkers(visitMarkers(add.getMarkers(), p));
+    }
+
+    public Docker visitCopy(Docker.Copy copy, P p) {
+        return copy
+                .withPrefix(visitSpace(copy.getPrefix(), p))
+                .withOptions(ListUtils.map(copy.getOptions(), o -> visitAndCast(o, p)))
+                .withSources(ListUtils.map(copy.getSources(), s -> visitAndCast(s, p)))
+                .withDestination(visitAndCast(copy.getDestination(), p))
+                .withMarkers(visitMarkers(copy.getMarkers(), p));
+    }
+
+    public Docker visitEntrypoint(Docker.Entrypoint entrypoint, P p) {
+        return entrypoint
+                .withForm(entrypoint.getForm())
+                .withPrefix(visitSpace(entrypoint.getPrefix(), p))
+                .withExecFormPrefix(visitSpace(entrypoint.getExecFormPrefix(), p))
+                .withCommands(ListUtils.map(entrypoint.getCommands(), c -> visitAndCast(c, p)))
+                .withExecFormSuffix(visitSpace(entrypoint.getExecFormSuffix(), p))
+                .withMarkers(visitMarkers(entrypoint.getMarkers(), p));
+    }
+
+    public Docker visitVolume(Docker.Volume volume, P p) {
+        return volume
+                .withForm(volume.getForm())
+                .withPrefix(visitSpace(volume.getPrefix(), p))
+                .withExecFormPrefix(visitSpace(volume.getExecFormPrefix(), p))
+                .withPaths(ListUtils.map(volume.getPaths(), path -> visitAndCast(path, p)))
+                .withExecFormSuffix(visitSpace(volume.getExecFormSuffix(), p))
+                .withMarkers(visitMarkers(volume.getMarkers(), p));
+    }
+
+    public Docker visitUser(Docker.User user, P p) {
+        return user
+                .withPrefix(visitSpace(user.getPrefix(), p))
+                .withUsername(visitAndCast(user.getUsername(), p))
+                .withGroup(visitAndCast(user.getGroup(), p))
+                .withMarkers(visitMarkers(user.getMarkers(), p));
+    }
+
+    public Docker visitWorkdir(Docker.Workdir workdir, P p) {
+        return workdir
+                .withPrefix(visitSpace(workdir.getPrefix(), p))
+                .withPath(visitAndCast(workdir.getPath(), p))
+                .withMarkers(visitMarkers(workdir.getMarkers(), p));
+    }
+
+    public Docker visitArg(Docker.Arg arg, P p) {
+        return arg
+                .withPrefix(visitSpace(arg.getPrefix(), p))
+                .withArgs(ListUtils.map(arg.getArgs(), a -> visitDockerRightPadded(a, p)))
+                .withMarkers(visitMarkers(arg.getMarkers(), p));
+    }
+
+    public Docker visitOnBuild(Docker.OnBuild onBuild, P p) {
+        return onBuild
+                .withPrefix(visitSpace(onBuild.getPrefix(), p))
+                .withInstruction(visitAndCast(onBuild.getInstruction(), p))
+                .withTrailing(visitSpace(onBuild.getTrailing(), p))
+                .withMarkers(visitMarkers(onBuild.getMarkers(), p));
+    }
+
+    public Docker visitStopSignal(Docker.StopSignal stopSignal, P p) {
+        return stopSignal
+                .withPrefix(visitSpace(stopSignal.getPrefix(), p))
+                .withSignal(visitAndCast(stopSignal.getSignal(), p))
+                .withMarkers(visitMarkers(stopSignal.getMarkers(), p));
+    }
+
+    public Docker visitHealthcheck(Docker.Healthcheck healthcheck, P p) {
+        return healthcheck
+                .withPrefix(visitSpace(healthcheck.getPrefix(), p))
+                .withType(healthcheck.getType())
+                .withOptions(ListUtils.map(healthcheck.getOptions(), o -> visitDockerRightPadded(o, p)))
+                .withCommands(ListUtils.map(healthcheck.getCommands(), c -> visitAndCast(c, p)))
+                .withMarkers(visitMarkers(healthcheck.getMarkers(), p));
+    }
+
+    public Docker visitShell(Docker.Shell shell, P p) {
+        return shell
+                .withPrefix(visitSpace(shell.getPrefix(), p))
+                .withExecFormPrefix(visitSpace(shell.getExecFormPrefix(), p))
+                .withCommands(ListUtils.map(shell.getCommands(), c -> visitAndCast(c, p)))
+                .withExecFormSuffix(visitSpace(shell.getExecFormSuffix(), p))
+                .withMarkers(visitMarkers(shell.getMarkers(), p));
+    }
+
+    public Docker visitDirective(Docker.Directive directive, P p) {
+        return directive.withPrefix(visitSpace(directive.getPrefix(), p))
+                .withDirective(visitDockerRightPadded(directive.getDirective(), p)) // Assuming the name doesn't need visiting
+                .withMarkers(visitMarkers(directive.getMarkers(), p));
+    }
+
+    public Docker visitLiteral(Docker.Literal literal, P p) {
+        return literal.withPrefix(visitSpace(literal.getPrefix(), p))
+                .withQuoting(literal.getQuoting()) // Assuming quoting doesn't need visiting
+                .withMarkers(visitMarkers(literal.getMarkers(), p));
+    }
+
+    public Docker visitOption(Docker.Option option, P p) {
+        return option.withPrefix(visitSpace(option.getPrefix(), p))
+                .withKeyArgs(option.getKeyArgs()) // Assuming the key doesn't need visitingx
+                .withMarkers(visitMarkers(option.getMarkers(), p));
+    }
+
+    public <T> DockerRightPadded<T> visitDockerRightPadded(DockerRightPadded<T> right, P p) {
+        if (right == null) {
+            //noinspection ConstantConditions
+            return null;
+        }
+
+        setCursor(new Cursor(getCursor(), right));
+
+        T t = right.getElement();
+        if (t instanceof Docker) {
+            //noinspection unchecked
+            t = visitAndCast((Docker) right.getElement(), p);
+        } else if (t instanceof Docker.KeyArgs) {
+            Docker.KeyArgs args = (Docker.KeyArgs) right.getElement();
+            //noinspection unchecked
+            t = (T) args.withPrefix(visitSpace(args.getPrefix(), p))
+                    .withKey(visitAndCast(args.getKey(), p))
+                    .withValue(visitAndCast(args.getValue(), p))
+                    .withQuoting(args.getQuoting());
+        }
+
+        setCursor(getCursor().getParent());
+        if (t == null) {
+            //noinspection ConstantConditions
+            return null;
+        }
+
+        Space after = visitSpace(right.getAfter(), p);
+        Markers markers = visitMarkers(right.getMarkers(), p);
+        return (after == right.getAfter() && t == right.getElement() && markers == right.getMarkers()) ?
+                right : new DockerRightPadded<>(t, after, markers);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/DockerVisitor.java
+++ b/src/main/java/org/openrewrite/docker/DockerVisitor.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/DockerVisitor.java
+++ b/src/main/java/org/openrewrite/docker/DockerVisitor.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
-import org.openrewrite.docker.tree.DockerRightPadded;
-import org.openrewrite.docker.tree.Space;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.Markers;
 

--- a/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
+++ b/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanned> {
     private static final String DEFAULT_EXCLUDES = ".env,.log,.tmp,.bak,.swp,.DS_Store,.class,.md,.txt,.adoc,.git,.idea,.vscode,.gradle,.mvn";
 
+    @Nullable
     @Option(
             displayName = "Excludes",
             description = "A comma-separated list of patterns to exclude from the .dockerignore file.",
@@ -63,7 +64,7 @@ public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanne
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
-        return new TreeVisitor<>() {
+        return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext, Cursor parent) {
                 if (tree == null) {
@@ -99,7 +100,7 @@ public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanne
                     return Collections.emptyList();
                 }
 
-                return Collections.singletonList(PlainText.builder()
+                return Arrays.asList(PlainText.builder()
                         .text(toAppend)
                         .sourcePath(target)
                         .build());
@@ -111,7 +112,7 @@ public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanne
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
-        return Preconditions.check(acc.found, new TreeVisitor<>() {
+        return Preconditions.check(acc.found, new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree != null) {
@@ -142,7 +143,7 @@ public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanne
         if (excludes == null || excludes.isEmpty()) {
             return "";
         }
-        Set<String> toBeExcluded = new HashSet<>(List.of(excludes.split(",")));
+        Set<String> toBeExcluded = new HashSet<>(Arrays.asList(excludes.split(",")));
         toBeExcluded.removeAll(existingExcludes);
         return toBeExcluded.stream()
                 .map(String::trim)

--- a/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
+++ b/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.text.PlainText;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class EnsureDockerignore extends ScanningRecipe<EnsureDockerignore.Scanned> {
+    private static final String DEFAULT_EXCLUDES = ".env,.log,.tmp,.bak,.swp,.DS_Store,.class,.md,.txt,.adoc,.git,.idea,.vscode,.gradle,.mvn";
+
+    @Option(
+            displayName = "Excludes",
+            description = "A comma-separated list of patterns to exclude from the .dockerignore file.",
+            example = ".env,*.log,*.tmp,*.bak,*.swp,*.DS_Store,*.class,*.md,*.txt,*.adoc,.git,.idea/,.vscode/,.gradle/,.mvn/",
+            required = false
+    )
+    String excludes;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Ensure .dockerignore file exists";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Ensure that a .dockerignore file exists in the project root with (at a minimum) the recommended excludes patterns.";
+    }
+
+    @Override
+    public Scanned getInitialValue(ExecutionContext ctx) {
+        return new Scanned();
+    }
+
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
+        return new TreeVisitor<>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext, Cursor parent) {
+                if (tree == null) {
+                    return tree;
+                }
+
+                SourceFile file = (SourceFile) tree;
+                if (file.getSourcePath().endsWith("Dockerfile") || file.getSourcePath().endsWith(".dockerignore")) {
+                    // if dockerfile, and .dockerignore is never loaded as plain text, this will retrieve from the file
+                    evaluatePath(acc, file.getSourcePath());
+
+                    // but if it's a .dockerignore, we can also read in the content, which will include any recipe updates to this point
+                    if (file.getSourcePath().endsWith(".dockerignore")) {
+                        evaluateContent(acc, file.printAll());
+                    }
+
+                    acc.found = true;
+                }
+                return file;
+            }
+        };
+    }
+
+
+    @Override
+    public Collection<? extends SourceFile> generate(Scanned acc, Collection<SourceFile> generatedInThisCycle, ExecutionContext ctx) {
+        Collection<? extends SourceFile> result = Collections.emptyList();
+        if (!acc.found) {
+            Path target = Paths.get(".dockerignore");
+            if (generatedInThisCycle.stream().noneMatch(f -> f.getSourcePath().equals(target))) {
+                String toAppend = remainingExcludes(getExcludes(), acc.existingExcludes);
+                if (toAppend.isEmpty()) {
+                    return Collections.emptyList();
+                }
+
+                return Collections.singletonList(PlainText.builder()
+                        .text(toAppend)
+                        .sourcePath(target)
+                        .build());
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        return Preconditions.check(acc.found, new TreeVisitor<>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree != null) {
+                    SourceFile file = (SourceFile) tree;
+                    if (file.getSourcePath().endsWith(".dockerignore")) {
+                        // evaluate the file to see if it exists and if it has the excludes we need
+
+                        PlainText plainText = (PlainText) file;
+                        String original = plainText.printAll();
+                        if (!original.endsWith("\n")) {
+                            original = original + "\n";
+                        }
+                        evaluateContent(acc, original);
+                        String append = remainingExcludes(getExcludes(), acc.existingExcludes);
+
+                        return append.isEmpty() ?
+                                tree :
+                                plainText.withText(original + append);
+                    }
+                    return file;
+                }
+                return null;
+            }
+        });
+    }
+
+    private String remainingExcludes(String excludes, Set<String> existingExcludes) {
+        if (excludes == null || excludes.isEmpty()) {
+            return "";
+        }
+        Set<String> toBeExcluded = new HashSet<>(List.of(excludes.split(",")));
+        toBeExcluded.removeAll(existingExcludes);
+        return toBeExcluded.stream()
+                .map(String::trim)
+                .filter(pattern -> !pattern.isEmpty())
+                .sorted()
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private String getExcludes() {
+        if (excludes == null || excludes.isEmpty()) {
+            return DEFAULT_EXCLUDES;
+        }
+        return excludes;
+    }
+
+    private void evaluatePath(Scanned acc, Path path) {
+        // path is the Source path or .dockerignore path,
+        // get the root path of the Dockerfile to construct the .dockerignore path
+        // and check if it exists.
+        if (path.toFile().exists() && path.getFileName().endsWith(".dockerignore")) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(path.toFile()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    line = line.trim();
+                    if (line.isEmpty() || line.startsWith("#")) {
+                        continue;
+                    }
+                    acc.existingExcludes.add(line);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void evaluateContent(Scanned acc, String content) {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        String[] lines = content.split("\n");
+        for (String line : lines) {
+            line = line.trim();
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+            acc.existingExcludes.add(line);
+        }
+    }
+
+    public static class Scanned {
+        boolean found;
+        Set<String> existingExcludes = new HashSet<>();
+    }
+}

--- a/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
+++ b/src/main/java/org/openrewrite/docker/EnsureDockerignore.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/ModifyLiteral.java
+++ b/src/main/java/org/openrewrite/docker/ModifyLiteral.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/ModifyLiteral.java
+++ b/src/main/java/org/openrewrite/docker/ModifyLiteral.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.trait.DockerLiteral;
+import lombok.*;
+import org.openrewrite.*;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class ModifyLiteral extends Recipe {
+    @Option(displayName = "Match text",
+            description = "A regular expression to match against text.",
+            example = ".*/java-17/.*")
+    String matchText;
+
+    @Option(displayName = "Replacement text",
+            description = "The replacement text for the matched text. " +
+                          "This will replace the full literal text, or a single matching group defined in `matchText`. " +
+                          "Be careful as this may result in an invalid Dockerfile.",
+            example = "java-21")
+    String replacementText;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Modify literal text within a Dockerfile";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Modify literal text within a Dockerfile.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        if (matchText == null || matchText.isEmpty()) {
+            return TreeVisitor.noop();
+        }
+
+        return DockerLiteral.matcher(matchText)
+                .asVisitor(n -> {
+                    if (replacementText == null || replacementText.isEmpty()) {
+                        return n.withText(replacementText).getTree();
+                    }
+
+                    if (n.getTree().getMarkers().findFirst(Modified.class).filter(
+                            m -> m.matchText.equals(matchText) && m.replacementText.equals(replacementText)
+                    ).isPresent()) {
+                        return n.getTree();
+                    }
+
+                    String text = n.getText();
+                    if (text != null) {
+                        Modified m = new Modified(
+                                UUID.randomUUID(),
+                                matchText,
+                                replacementText
+                        );
+
+                        Matcher matcher = Pattern.compile(matchText).matcher(n.getText());
+                        if (matcher.matches()) {
+                            if (matcher.groupCount() > 0) {
+                                String newText = text;
+                                for (int i = 1; i <= matcher.groupCount(); i++) {
+                                    String group = matcher.group(i);
+                                    if (group != null) {
+                                        newText = newText.replace(group, replacementText);
+                                    }
+                                }
+                                return n.withText(newText).getTree()
+                                        .withMarkers(n.getTree().getMarkers().addIfAbsent(m));
+                            }
+
+                            return n.withText(matcher.replaceAll(replacementText)).getTree()
+                                    .withMarkers(n.getTree().getMarkers().addIfAbsent(m));
+                        }
+                    }
+
+                    return n.getTree();
+                });
+    }
+
+    @Value
+    static class Modified implements Marker {
+        @EqualsAndHashCode.Exclude
+        @With
+        UUID id;
+
+        String matchText;
+        String replacementText;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/ModifyLiteral.java
+++ b/src/main/java/org/openrewrite/docker/ModifyLiteral.java
@@ -14,9 +14,9 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.trait.DockerLiteral;
 import lombok.*;
 import org.openrewrite.*;
+import org.openrewrite.docker.trait.DockerLiteral;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;

--- a/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
+++ b/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
@@ -14,13 +14,14 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.trait.Traits;
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.trait.Traits;
+import org.openrewrite.docker.tree.Docker;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -32,6 +33,7 @@ public class ModifyOptionValue extends Recipe {
             example = ".*/mount/.*")
     String matchKey;
 
+    @Nullable
     @Option(displayName = "Match value regex",
             description = "A regular expression to match against text of the value.",
             example = ".*/var/lib/apt.*",
@@ -43,6 +45,7 @@ public class ModifyOptionValue extends Recipe {
             example = "java-21")
     String replacementText;
 
+    @Nullable
     @Option(displayName = "The parent instruction",
             description = "An uppercase Docker instruction to match against exactly. " +
                           "This is not a regex match, but a case-sensitive exact match. " +
@@ -52,6 +55,7 @@ public class ModifyOptionValue extends Recipe {
             required = false)
     String parent;
 
+    @Nullable
     @Option(displayName = "Match instruction regex",
             description = "A regular expression to match against the full instruction text.",
             example = ".*https://.+",

--- a/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
+++ b/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
+++ b/src/main/java/org/openrewrite/docker/ModifyOptionValue.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.trait.Traits;
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.*;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class ModifyOptionValue extends Recipe {
+    @Option(displayName = "Match key regex",
+            description = "A regular expression to match against text of the key.",
+            example = ".*/mount/.*")
+    String matchKey;
+
+    @Option(displayName = "Match value regex",
+            description = "A regular expression to match against text of the value.",
+            example = ".*/var/lib/apt.*",
+            required = false)
+    String matchValue;
+
+    @Option(displayName = "Replacement value",
+            description = "The text to set for the value of the matching option.",
+            example = "java-21")
+    String replacementText;
+
+    @Option(displayName = "The parent instruction",
+            description = "An uppercase Docker instruction to match against exactly. " +
+                          "This is not a regex match, but a case-sensitive exact match. " +
+                          "Supported values are RUN, ADD, COPY." +
+                          "If matchInstructionRegex is set to true, this value may be a regex match against the _entire_ instruction text.",
+            example = "RUN",
+            required = false)
+    String parent;
+
+    @Option(displayName = "Match instruction regex",
+            description = "A regular expression to match against the full instruction text.",
+            example = ".*https://.+",
+            required = false)
+    boolean matchInstructionRegex;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Modify option value within a Dockerfile";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Modify option value within a Dockerfile.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        if (parent == null || parent.isEmpty()) {
+            return Traits.option(matchKey, matchValue, true)
+                    .asVisitor(n -> {
+                        Docker.KeyArgs args = n.getTree().getKeyArgs();
+                        return n.withArgs(args.withValue(args.getValue().withText(replacementText)))
+                                .getTree();
+                    });
+        }
+
+        return Traits.option(matchKey, matchValue, true)
+                .asVisitor(n -> {
+                    if (matchInstructionRegex) {
+                        Tree tree = n.getCursor().getParent().getValue();
+                        String text = tree.printTrimmed(new Cursor(n.getCursor().getParent(), tree));
+                        if (!text.matches(parent)) {
+                            return n.getTree();
+                        }
+                    } else {
+                        Class<? extends Docker.Instruction> parentTarget;
+                        switch (parent.toUpperCase()) {
+                            case "RUN":
+                                parentTarget = Docker.Run.class;
+                                break;
+                            case "ADD":
+                                parentTarget = Docker.Add.class;
+                                break;
+                            case "COPY":
+                                parentTarget = Docker.Copy.class;
+                                break;
+                            default:
+                                throw new IllegalArgumentException("Invalid parent instruction: " + parent);
+                        }
+
+                        if (!parentTarget.isInstance(n.getCursor().getParent().getValue())) {
+                            return n.getTree();
+                        }
+                    }
+
+
+                    Docker.KeyArgs args = n.getTree().getKeyArgs();
+                    return n.withArgs(args.withValue(args.getValue().withText(replacementText)))
+                            .getTree();
+                });
+    }
+}

--- a/src/main/java/org/openrewrite/docker/NameAllStages.java
+++ b/src/main/java/org/openrewrite/docker/NameAllStages.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Marker;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class NameAllStages extends Recipe {
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Name all stages";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Name all stages in a Dockerfile (except the final stage).";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
+                for (int i = dockerfile.getStages().size() - 1; i >= 0; i--) {
+                    Docker.Stage stage = dockerfile.getStages().get(i);
+                    stage = stage.withMarkers(stage.getMarkers().addIfAbsent(new Counter(UUID.randomUUID(), i, i == dockerfile.getStages().size() - 1)));
+                    dockerfile.getStages().set(i, stage);
+                }
+
+                return super.visitDocument(dockerfile, ctx);
+            }
+
+            @Override
+            public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
+                Docker.Stage stage = Objects.requireNonNull(getCursor().getParent()).firstEnclosing(Docker.Stage.class);
+                if (stage != null && stage.getMarkers() != null && stage.getMarkers().findFirst(Counter.class).isPresent()) {
+                    Counter counter = stage.getMarkers().findFirst(Counter.class).get();
+                    if (!counter.isLast && (from.getAlias().getText() == null || from.getAlias().getText().isEmpty())) {
+                        return from.alias("stage" + counter.index);
+                    }
+                }
+
+                return from;
+            }
+
+            @Override
+            public Docker.Copy visitCopy(Docker.Copy copy, ExecutionContext executionContext) {
+                if (copy.getOptions() != null && copy.getOptions().stream().anyMatch(
+                        o -> {
+                            Docker.KeyArgs key = o.getKeyArgs();
+                            return (key != null && "--from".equals(key.key())) && (key.value() != null && key.value().matches("^\\d+$"));
+                        })) {
+                    return copy.withOptions(
+                            ListUtils.map(copy.getOptions(), o -> {
+                                if (o == null) {
+                                    return o;
+                                }
+
+                                Docker.KeyArgs key = o.getKeyArgs();
+                                if (key != null && "--from".equals(key.key()) && (key.value() != null && key.value().matches("^\\d+$"))) {
+                                    int index = Integer.parseInt(key.value());
+                                    return o.withKeyArgs(key.withValue(key.getValue().withText("stage" + index)));
+                                }
+
+                                return o;
+                            })
+                    );
+                }
+
+                return copy;
+            }
+        };
+    }
+
+    @Value
+    static class Counter implements Marker {
+        @EqualsAndHashCode.Exclude
+        @With
+        UUID id;
+
+        int index;
+        boolean isLast;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/NameAllStages.java
+++ b/src/main/java/org/openrewrite/docker/NameAllStages.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/NameAllStages.java
+++ b/src/main/java/org/openrewrite/docker/NameAllStages.java
@@ -14,7 +14,6 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -23,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.NlsRewrite;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.Marker;
 
@@ -45,7 +45,7 @@ public class NameAllStages extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
                 for (int i = dockerfile.getStages().size() - 1; i >= 0; i--) {

--- a/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class RemoveImagePlatform extends Recipe {
+    @Option(displayName = "A regular expression to locate an image entry.",
+            description = "A regular expression to locate an image entry, defaults to `.+` (all images).",
+            example = ".*",
+            required = false)
+    String matchImage;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove image platform";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove the platform from an image on the FROM instruction.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
+                String emptyPlatform = "";
+                if (".*".equals(matchImage) || ".+".equals(matchImage) || matchImage == null) {
+                    from = from.platform(emptyPlatform);
+                } else {
+                    Matcher matcher = Pattern.compile(matchImage).matcher(from.getImageSpecWithVersion());
+                    if (matcher.matches()) {
+                        from = from.platform(emptyPlatform);
+                    }
+                }
+                return super.visitFrom(from, executionContext);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/RemoveImagePlatform.java
@@ -14,15 +14,16 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.tree.Docker;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,6 +33,7 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 @NoArgsConstructor(force = true)
 public class RemoveImagePlatform extends Recipe {
+    @Nullable
     @Option(displayName = "A regular expression to locate an image entry.",
             description = "A regular expression to locate an image entry, defaults to `.+` (all images).",
             example = ".*",
@@ -50,7 +52,7 @@ public class RemoveImagePlatform extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
                 String emptyPlatform = "";

--- a/src/main/java/org/openrewrite/docker/SetImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/SetImagePlatform.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/SetImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/SetImagePlatform.java
@@ -14,12 +14,13 @@
  */
 package org.openrewrite.docker;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.tree.Docker;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,6 +35,7 @@ public class SetImagePlatform extends Recipe {
             example = "linux/amd64")
     String platform;
 
+    @Nullable
     @Option(displayName = "A regular expression to locate an image entry.",
             description = "A regular expression to locate an image entry, defaults to `.+` (all images).",
             example = ".*",
@@ -52,7 +54,7 @@ public class SetImagePlatform extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
                 from = super.visitFrom(from, executionContext);

--- a/src/main/java/org/openrewrite/docker/SetImagePlatform.java
+++ b/src/main/java/org/openrewrite/docker/SetImagePlatform.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.*;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class SetImagePlatform extends Recipe {
+    @Option(displayName = "Platform",
+            description = "The platform to set in the FROM instruction.",
+            example = "linux/amd64")
+    String platform;
+
+    @Option(displayName = "A regular expression to locate an image entry.",
+            description = "A regular expression to locate an image entry, defaults to `.+` (all images).",
+            example = ".*",
+            required = false)
+    String matchImage;
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Set the --platform flag in a FROM instruction";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Set the --platform flag in a FROM instruction.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
+                from = super.visitFrom(from, executionContext);
+                if (matchImage == null || ".*".equals(matchImage) || ".+".equals(matchImage)) {
+                    return from.platform(platform);
+                }
+                Matcher matcher = Pattern.compile(matchImage).matcher(from.getImageSpecWithVersion());
+                if (matcher.matches()) {
+                    return from.platform(platform);
+                }
+
+                return from;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/docker/analysis/ListImages.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListImages.java
@@ -14,14 +14,14 @@
  */
 package org.openrewrite.docker.analysis;
 
-import org.openrewrite.docker.DockerIsoVisitor;
-import org.openrewrite.docker.table.ImageUseReport;
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.table.ImageUseReport;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.marker.SearchResult;
 
 import java.nio.file.Path;
@@ -51,7 +51,7 @@ public class ListImages extends ScanningRecipe<List<ImageUseReport.Row>> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(List<ImageUseReport.Row> acc) {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
                 Path file = dockerfile.getSourcePath();

--- a/src/main/java/org/openrewrite/docker/analysis/ListImages.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListImages.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/analysis/ListImages.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListImages.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.analysis;
+
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.table.ImageUseReport;
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.marker.SearchResult;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class ListImages extends ScanningRecipe<List<ImageUseReport.Row>> {
+    @EqualsAndHashCode.Exclude
+    transient ImageUseReport report = new ImageUseReport(this);
+
+    @Override
+    public String getDisplayName() {
+        return "List docker images";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A recipe which outputs a data table describing the images referenced in the Dockerfile.";
+    }
+
+    @Override
+    public List<ImageUseReport.Row> getInitialValue(ExecutionContext ctx) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(List<ImageUseReport.Row> acc) {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
+                Path file = dockerfile.getSourcePath();
+
+                if (dockerfile.getStages() != null) {
+                    List<Docker.Stage> stages = dockerfile.getStages();
+                    for (int i = 0; i < stages.size(); i++) {
+                        Docker.Stage stage = stages.get(i);
+                        if (stage != null) {
+                            for (Docker child : stage.getChildren()) {
+                                if (child instanceof Docker.From) {
+                                    Docker.From from = (Docker.From) child;
+                                    String platformSwitch = null;
+                                    if (from.getPlatform().getText() != null) {
+                                        platformSwitch = from.getPlatform().getText().split("=")[1];
+                                    }
+
+                                    acc.add(new ImageUseReport.Row(
+                                            file.toString(),
+                                            from.getImageSpec(),
+                                            from.getTag(),
+                                            from.getDigest(),
+                                            platformSwitch,
+                                            from.getAlias().getText(),
+                                            i
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!acc.isEmpty()) {
+                    return SearchResult.found(dockerfile);
+                }
+                return dockerfile;
+            }
+        };
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(List<ImageUseReport.Row> acc, Collection<SourceFile> generatedInThisCycle, ExecutionContext ctx) {
+        for (ImageUseReport.Row row : acc) {
+            report.insertRow(ctx, row);
+        }
+        acc.clear();
+
+        return super.generate(Collections.emptyList(), generatedInThisCycle, ctx);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/analysis/ListImages.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListImages.java
@@ -41,7 +41,7 @@ public class ListImages extends ScanningRecipe<List<ImageUseReport.Row>> {
 
     @Override
     public String getDescription() {
-        return "A recipe which outputs a data table describing the images referenced in the Dockerfile.";
+        return "Outputs a data table describing the images referenced in the Dockerfile.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
@@ -41,7 +41,7 @@ public class ListRemoteFiles extends ScanningRecipe<List<RemoteFileReport.Row>> 
 
     @Override
     public String getDescription() {
-        return "A recipe which outputs a data table describing the remote files referenced in the Dockerfile.";
+        return "Outputs a data table describing the remote files referenced in the Dockerfile.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.analysis;
+
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.table.RemoteFileReport;
+import org.openrewrite.docker.tree.Docker;
+import lombok.EqualsAndHashCode;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ListRemoteFiles extends ScanningRecipe<List<RemoteFileReport.Row>> {
+    @EqualsAndHashCode.Exclude
+    transient RemoteFileReport report = new RemoteFileReport(this);
+
+    @Override
+    public String getDisplayName() {
+        return "List remote files";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A recipe which outputs a data table describing the remote files referenced in the Dockerfile.";
+    }
+
+    @Override
+    public List<RemoteFileReport.Row> getInitialValue(ExecutionContext ctx) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(List<RemoteFileReport.Row> acc) {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
+                if (dockerfile.getStages() != null) {
+                    for (Docker.Stage stage : dockerfile.getStages()) {
+                        if (stage != null) {
+                            for (Docker child : stage.getChildren()) {
+                                if (child instanceof Docker.Add) {
+                                    Docker.Add instruction = (Docker.Add) child;
+                                    List<Docker.Literal> urls = instruction.getSources().stream()
+                                            .filter(s -> s.getText().startsWith("http"))
+                                            .collect(Collectors.toList());
+
+                                    if (!urls.isEmpty()) {
+                                        urls.forEach(url -> {
+                                            acc.add(new RemoteFileReport.Row(
+                                                    dockerfile.getSourcePath().toString(),
+                                                    url.getText()
+                                            ));
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if (!acc.isEmpty()) {
+                    return SearchResult.found(dockerfile);
+                }
+                return dockerfile;
+            }
+        };
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(List<RemoteFileReport.Row> acc, ExecutionContext ctx) {
+        if (acc.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        for (RemoteFileReport.Row row : acc) {
+            report.insertRow(ctx, row);
+        }
+
+        acc.clear();
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/org/openrewrite/docker/analysis/ListRemoteFiles.java
@@ -14,14 +14,14 @@
  */
 package org.openrewrite.docker.analysis;
 
-import org.openrewrite.docker.DockerIsoVisitor;
-import org.openrewrite.docker.table.RemoteFileReport;
-import org.openrewrite.docker.tree.Docker;
 import lombok.EqualsAndHashCode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.table.RemoteFileReport;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.ArrayList;
@@ -51,7 +51,7 @@ public class ListRemoteFiles extends ScanningRecipe<List<RemoteFileReport.Row>> 
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(List<RemoteFileReport.Row> acc) {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Document visitDocument(Docker.Document dockerfile, ExecutionContext ctx) {
                 if (dockerfile.getStages() != null) {

--- a/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
+++ b/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
@@ -14,10 +14,6 @@
  */
 package org.openrewrite.docker.format;
 
-import org.openrewrite.docker.DockerIsoVisitor;
-import org.openrewrite.docker.tree.Docker;
-import org.openrewrite.docker.tree.DockerRightPadded;
-import org.openrewrite.docker.tree.Quoting;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -25,6 +21,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.NlsRewrite;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.internal.ListUtils;
 
 import java.util.List;
@@ -45,7 +45,7 @@ public class FixAlternateEnvSyntax extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.Env visitEnv(Docker.Env env, ExecutionContext executionContext) {
                 // note that we will not "undo" Docker's documented caveat.

--- a/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
+++ b/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.format;
+
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class FixAlternateEnvSyntax extends Recipe {
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Fix alternate ENV syntax";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Fix alternate ENV syntax by ensuring 'key=value' syntax is used instead of 'key value' syntax.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Env visitEnv(Docker.Env env, ExecutionContext executionContext) {
+                // note that we will not "undo" Docker's documented caveat.
+                // ENV ONE TWO= THREE=world would be parsed by Docker as ONE="TWO= THREE=world".
+                // This recipe will not change that behavior and will only add the equals and ensure
+                // the resulting string is correct.
+                List<DockerRightPadded<Docker.KeyArgs>> args = ListUtils.flatMap(
+                        env.getArgs(),
+                        keyArgs -> keyArgs.map(a -> {
+                            a = a.withHasEquals(true);
+                            if (a.getValue().getText().contains(" ") && a.getQuoting() != Quoting.DOUBLE_QUOTED) {
+                                a = a.withQuoting(Quoting.DOUBLE_QUOTED);
+                            }
+
+                            return a;
+                        })
+                );
+                env = env.withArgs(args);
+                return super.visitEnv(env, executionContext);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
+++ b/src/main/java/org/openrewrite/docker/format/FixAlternateEnvSyntax.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
+++ b/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.format;
+
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.InstructionName;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class UppercaseInstructionNames extends Recipe {
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Uppercase instruction names";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Uppercase instruction names in Dockerfile to match Dockerfile best practices.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
+                return super.visitFrom(from.withMarkers(from.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Run visitRun(Docker.Run run, ExecutionContext executionContext) {
+                return super.visitRun(run.withMarkers(run.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Cmd visitCmd(Docker.Cmd cmd, ExecutionContext executionContext) {
+                return super.visitCmd(cmd.withMarkers(cmd.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Label visitLabel(Docker.Label label, ExecutionContext executionContext) {
+                return super.visitLabel(label.withMarkers(label.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Maintainer visitMaintainer(Docker.Maintainer maintainer, ExecutionContext executionContext) {
+                return super.visitMaintainer(maintainer.withMarkers(maintainer.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Expose visitExpose(Docker.Expose expose, ExecutionContext executionContext) {
+                return super.visitExpose(expose.withMarkers(expose.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Env visitEnv(Docker.Env env, ExecutionContext executionContext) {
+                return super.visitEnv(env.withMarkers(env.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Add visitAdd(Docker.Add add, ExecutionContext executionContext) {
+                return super.visitAdd(add.withMarkers(add.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Copy visitCopy(Docker.Copy copy, ExecutionContext executionContext) {
+                return super.visitCopy(copy.withMarkers(copy.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Entrypoint visitEntrypoint(Docker.Entrypoint entrypoint, ExecutionContext executionContext) {
+                return super.visitEntrypoint(entrypoint.withMarkers(entrypoint.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Volume visitVolume(Docker.Volume volume, ExecutionContext executionContext) {
+                return super.visitVolume(volume.withMarkers(volume.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.User visitUser(Docker.User user, ExecutionContext executionContext) {
+                return super.visitUser(user.withMarkers(user.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Workdir visitWorkdir(Docker.Workdir workdir, ExecutionContext executionContext) {
+                return super.visitWorkdir(workdir.withMarkers(workdir.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Arg visitArg(Docker.Arg arg, ExecutionContext executionContext) {
+                return super.visitArg(arg.withMarkers(arg.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.OnBuild visitOnBuild(Docker.OnBuild onBuild, ExecutionContext executionContext) {
+                return super.visitOnBuild(onBuild.withMarkers(onBuild.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.StopSignal visitStopSignal(Docker.StopSignal stopSignal, ExecutionContext executionContext) {
+                return super.visitStopSignal(stopSignal.withMarkers(stopSignal.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Healthcheck visitHealthcheck(Docker.Healthcheck healthcheck, ExecutionContext executionContext) {
+                return super.visitHealthcheck(healthcheck.withMarkers(healthcheck.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+
+            @Override
+            public Docker.Shell visitShell(Docker.Shell shell, ExecutionContext executionContext) {
+                return super.visitShell(shell.withMarkers(shell.getMarkers().removeByType(InstructionName.class)), executionContext);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
+++ b/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
@@ -14,9 +14,6 @@
  */
 package org.openrewrite.docker.format;
 
-import org.openrewrite.docker.DockerIsoVisitor;
-import org.openrewrite.docker.tree.Docker;
-import org.openrewrite.docker.tree.InstructionName;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -24,6 +21,9 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.NlsRewrite;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.DockerIsoVisitor;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.InstructionName;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -41,7 +41,7 @@ public class UppercaseInstructionNames extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DockerIsoVisitor<>() {
+        return new DockerIsoVisitor<ExecutionContext>() {
             @Override
             public Docker.From visitFrom(Docker.From from, ExecutionContext executionContext) {
                 return super.visitFrom(from.withMarkers(from.getMarkers().removeByType(InstructionName.class)), executionContext);

--- a/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
+++ b/src/main/java/org/openrewrite/docker/format/UppercaseInstructionNames.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
@@ -14,17 +14,15 @@
  */
 package org.openrewrite.docker.internal;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.InstructionName;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.io.InputStream;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,11 +38,11 @@ public class DockerfileParser {
     @SuppressWarnings({"RegExpSimplifiable", "RegExpRedundantEscape"})
     static final Pattern heredocPattern = Pattern.compile("<<[-]?(?<heredoc>[A-Z0-9]{3})([ \\t]*(?<redirect>[>]{0,2})[ \\t]*(?<target>[a-zA-Z0-9_.\\-\\/]*))?");
     private final ParserState state = new ParserState();
-    private static final Set<String> instructions = Set.of(
+    private static final Set<String> instructions = new HashSet<>(Arrays.asList(
             "ADD", "ARG", "CMD", "COPY", "ENTRYPOINT", "ENV", "EXPOSE", "FROM", "HEALTHCHECK",
             "LABEL", "MAINTAINER", "ONBUILD", "RUN", "SHELL", "STOPSIGNAL", "USER", "VOLUME",
             "WORKDIR", "#"
-    );
+    ));
 
     private final InstructionParserRegistry registry = new InstructionParserRegistry();
     private final StringBuilder instruction = new StringBuilder();

--- a/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/DockerfileParser.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.InstructionName;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.openrewrite.docker.internal.ParserConstants.*;
+
+/**
+ * Parses a Dockerfile into an AST.
+ * <p>
+ * This parser is not a full implementation of the Dockerfile syntax. It is designed to parse the most common
+ * instructions and handle the most common cases. It does not handle all edge cases or all possible syntax.
+ */
+public class DockerfileParser {
+    @SuppressWarnings({"RegExpSimplifiable", "RegExpRedundantEscape"})
+    static final Pattern heredocPattern = Pattern.compile("<<[-]?(?<heredoc>[A-Z0-9]{3})([ \\t]*(?<redirect>[>]{0,2})[ \\t]*(?<target>[a-zA-Z0-9_.\\-\\/]*))?");
+    private final ParserState state = new ParserState();
+    private static final Set<String> instructions = Set.of(
+            "ADD", "ARG", "CMD", "COPY", "ENTRYPOINT", "ENV", "EXPOSE", "FROM", "HEALTHCHECK",
+            "LABEL", "MAINTAINER", "ONBUILD", "RUN", "SHELL", "STOPSIGNAL", "USER", "VOLUME",
+            "WORKDIR", "#"
+    );
+
+    private final InstructionParserRegistry registry = new InstructionParserRegistry();
+    private final StringBuilder instruction = new StringBuilder();
+    private String instructionType = null;
+
+    /**
+     * Parses a Dockerfile into an LST.
+     *
+     * @param input The input stream to parse.
+     * @return The parsed Dockerfile as a {@link Docker.Document}.
+     */
+    public Docker.Document parse(InputStream input) {
+        // TODO: handle parser errors, such as unmatched quotes, invalid syntax, etc.
+        // TODO: handle syntax version differences (or just support the latest according to https://docs.docker.com/engine/reference/builder/ ??)
+        // scan the input stream and maintain state. A newline is the name for a complete instruction unless escaped.
+        // when a complete instruction is found, parse it into an AST node
+        List<Docker.Stage> stages = new ArrayList<>();
+        List<Docker.Instruction> currentInstructions = new ArrayList<>();
+
+        Space eof = Space.EMPTY;
+        try (FullLineIterator scanner = new FullLineIterator(input)) {
+            while (scanner.hasNext()) {
+                String line = scanner.next();
+                Space eol = scanner.hasEol() ? Space.build(NEWLINE) : Space.EMPTY;
+
+                // if the line ends in /r, we need to remove it and prepend it to newline above
+                if (!line.isEmpty() && line.charAt(line.length() - 1) == '\r') {
+                    eol = Space.append(Space.build("\r"), eol);
+                    line = line.substring(0, line.length() - 1);
+                }
+
+                line = handleLeadingWhitespace(line, state);
+                if (line.isEmpty()) {
+                    eof = Space.append(eof, eol);
+                    continue;
+                }
+
+                line = handleRightPadding(line, state);
+
+                // TODO: consider a better way to handle "inline" comments
+                if (state.isContinuation() && line.startsWith("#")) {
+                    instruction.append(line);
+                    instruction.append(eol.getWhitespace());
+                    continue;
+                }
+
+
+                String instructionName = peekInstruction(line);
+                if (state.isContinuation()
+                    && "HEALTHCHECK".equalsIgnoreCase(instructionType)
+                    && "CMD".equalsIgnoreCase(instructionName)) {
+                    // if we are in a HEALTHCHECK and the next word is CMD, we need to treat this as a continuation
+                    // of the previous instruction, not a new one.
+                    line = state.prefix().getWhitespace() + line;
+                    state.resetPrefix();
+                } else if (instructionName != null) {
+                    instructionType = instructionName;
+                    line = line.substring(instructionName.length());
+                } else if (state.prefix() != null && !state.prefix().isEmpty()) {
+                    line = state.prefix().getWhitespace() + line;
+                    state.resetPrefix();
+                }
+
+                String beforeHeredoc = line;
+                line = handleHeredoc(line, scanner);
+                if (!beforeHeredoc.equals(line)) {
+                    eol = Space.EMPTY; // clear, let heredoc handle this.
+                }
+
+                instruction.append(line);
+                // TODO: should we throw an error here if the line ends in the escape char and there are no more lines?
+                if (scanner.hasNext() && line.endsWith(state.getEscapeString())) {
+                    instruction.append(eol.getWhitespace());
+                    state.isContinuation(true);
+                    continue;
+                }
+
+                if (!eof.isEmpty() && (state.isContinuation() || scanner.hasNext())) {
+                    // any previously gathered whitespace is the prefix to this instruction
+                    state.appendPrefix(eof);
+                    eof = Space.EMPTY;
+                }
+
+                if (!scanner.hasNext()) {
+                    // if we are at the end of the file with a newline, that is our eof.
+                    // other conditions such as multiple newlines or whitespace are handled earlier
+                    eof = Space.append(eof, eol);
+                    eol = Space.EMPTY;
+                }
+
+                Docker.Instruction instr = registry.getParserFor(instructionType).parse(instruction.toString(), state);
+                if (instr != null) {
+                    instr = instr.withEol(eol);
+                    // if instructionType not upperCase, store the original casing in maker
+                    if (!instructionType.equals(instructionType.toUpperCase())) {
+                        instr = instr.withMarkers(instr.getMarkers().add(new InstructionName(Tree.randomId(), instructionType)));
+                    }
+                }
+                currentInstructions.add(instr);
+                if (instr instanceof Docker.From) {
+                    stages.add(new Docker.Stage(Tree.randomId(), new ArrayList<>(currentInstructions), Markers.EMPTY));
+                    currentInstructions.clear();
+                } else if (!stages.isEmpty()) {
+                    // if we have a stage, add the instruction to it
+                    stages.get(stages.size() - 1).getChildren().add(instr);
+                    currentInstructions.clear();
+                }
+                reset();
+            }
+        }
+
+        if (stages.isEmpty()) {
+            stages.add(new Docker.Stage(Tree.randomId(), new ArrayList<>(currentInstructions), Markers.EMPTY));
+        }
+
+        return new Docker.Document(Tree.randomId(), Paths.get("Dockerfile"), null, null, false, null, stages, eof, Markers.EMPTY);
+    }
+
+    /**
+     * Reset the parser state. This is used to clear the instruction buffer and reset the parser state.
+     */
+    private void reset() {
+        instruction.setLength(0);
+        state.reset();
+    }
+
+    /**
+     * Handle heredoc syntax in the line. This is used to handle the case where the line contains heredoc syntax.
+     * The heredoc syntax is removed from the line and the heredoc content is stored in the parser state.
+     *
+     * @param line    The line to handle.
+     * @param scanner The scanner to use to read the next lines.
+     * @return The line without the heredoc syntax.
+     */
+    private String handleHeredoc(String line, FullLineIterator scanner) {
+        // if the line does not have heredoc syntax, return the line
+        int heredocIndex = line.indexOf("<<-");
+        if (heredocIndex == -1) {
+            heredocIndex = line.indexOf("<<");
+            if (heredocIndex == -1) {
+                return line;
+            }
+        }
+
+        Matcher matcher = heredocPattern.matcher(line);
+        if (!matcher.find()) {
+            // not a heredoc
+            return line;
+        }
+
+        state.heredoc(new Heredoc(line.substring(heredocIndex), matcher.group("heredoc"), matcher.group("target")));
+
+        StringBuilder heredocContent = new StringBuilder(line);
+        if (scanner.hasEol()) {
+            heredocContent.append(NEWLINE);
+        }
+
+        while (scanner.hasNext()) {
+            line = scanner.next();
+            if (line.trim().equals(state.heredoc().name())) {
+                heredocContent.append(line);
+                if (scanner.hasEol()) {
+                    heredocContent.append(NEWLINE);
+                }
+                break;
+            }
+
+            heredocContent.append(line);
+            if (scanner.hasEol()) {
+                heredocContent.append(NEWLINE);
+            }
+        }
+
+        return heredocContent.toString();
+    }
+
+    /**
+     * Handle leading whitespace of the line. This is used to handle the case where the line starts with whitespace.
+     * The whitespace is stored in the parser state and removed from the line.
+     *
+     * @param line  The line to handle.
+     * @param state The parser state.
+     * @return The line without the leading whitespace.
+     */
+    private static String handleLeadingWhitespace(String line, ParserState state) {
+        // drain the line of any leading whitespace, storing in parser.addPrefix, then inspect the first "word" to determine the instruction type
+        while (line.startsWith(SPACE) || line.startsWith(TAB)) {
+            state.appendPrefix(Space.build(line.substring(0, 1)));
+            line = line.substring(1);
+        }
+        return line;
+    }
+
+    /**
+     * Handle right padding of the line. This is used to handle the case where the line ends with whitespace.
+     * The whitespace is stored in the parser state and removed from the line.
+     *
+     * @param line  The line to handle.
+     * @param state The parser state.
+     * @return The line without the right padding.
+     */
+    private static String handleRightPadding(String line, ParserState state) {
+        int idx = line.length() - 1;
+        // walk line backwards to find the last non-whitespace character
+        for (int i = line.length() - 1; i >= 0; i--) {
+            if (!Character.isWhitespace(line.charAt(i))) {
+                // move the pointer to after the current non-whitespace character
+                idx = i + 1;
+                break;
+            }
+        }
+
+        if (idx < line.length()) {
+            state.rightPadding(Space.append(state.rightPadding(), Space.build(line.substring(idx))));
+            line = line.substring(0, idx);
+        }
+        return line;
+    }
+
+    /**
+     * Peek at the first word of the line to determine if it is a valid instruction.
+     *
+     * @param line The line to peek at.
+     * @return The instruction name, or null if it is not a valid instruction.
+     */
+    private String peekInstruction(String line) {
+        if (line == null || line.isEmpty()) {
+            return null;
+        }
+
+        int i = 0;
+        while (i < line.length() && (line.charAt(i) == ' ' || line.charAt(i) == '\t')) {
+            i++;
+        }
+
+        int start = i;
+        if (line.charAt(i) == '#') {
+            i++;
+        } else {
+            while (i < line.length() && Character.isLetter(line.charAt(i))) {
+                i++;
+            }
+        }
+
+        String instr = line.substring(start, i);
+        if (instructions.contains(instr.toUpperCase())) {
+            return instr;
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/openrewrite/docker/internal/FullLineIterator.java
+++ b/src/main/java/org/openrewrite/docker/internal/FullLineIterator.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+
+/**
+ * An iterator that reads lines from an InputStream up to a newline character.
+ * This differs from Scanner which will splits on \r\n, \n, \r, and does not emit
+ * details about the line terminator.
+ */
+public class FullLineIterator implements Iterator<String>, AutoCloseable {
+    private final StringBuilder sb = new StringBuilder();
+    private boolean closed;
+    private boolean hasEol;
+    private boolean nextHasEol;
+
+    private final BufferedReader reader;
+    private String nextLine;
+    private IOException exception;
+
+    public FullLineIterator(InputStream inputStream) {
+        this.reader = new BufferedReader(new InputStreamReader(inputStream));
+        advance();
+        hasEol = nextHasEol;
+    }
+
+    private void advance() {
+        try {
+            int c;
+            sb.setLength(0);
+            nextHasEol = false;
+
+            while ((c = reader.read()) != -1) {
+                if (c == '\n') {
+                    nextHasEol = true;
+                    break;
+                }
+                sb.append((char) c);
+            }
+
+            // If we encountered end of file and no characters were read, return null
+            if (c == -1 && sb.length() == 0) {
+                nextLine = null;
+            } else {
+                // Otherwise return the line content (even if empty)
+                nextLine = sb.toString();
+            }
+
+            sb.setLength(0);
+        } catch (Exception e) {
+            sb.setLength(0);
+            throw new IllegalArgumentException("Error reading input stream", e);
+        }
+    }
+
+    public IOException exception() {
+        return exception;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return nextLine != null;
+    }
+
+    public boolean hasEol() {
+        return hasEol;
+    }
+
+    @Override
+    public String next() {
+        String currentLine = nextLine;
+        hasEol = nextHasEol;
+        advance();
+        return currentLine;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+
+        try {
+            reader.close();
+        } catch (IOException e) {
+            exception = e;
+        }
+        closed = true;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/FullLineIterator.java
+++ b/src/main/java/org/openrewrite/docker/internal/FullLineIterator.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/Heredoc.java
+++ b/src/main/java/org/openrewrite/docker/internal/Heredoc.java
@@ -23,10 +23,10 @@ import lombok.experimental.Accessors;
 /**
  * Represents a Heredoc structure in the context of defining content using
  * a unique indicator, name, and optional redirection target.
- *
+ * <p>
  * The Heredoc class provides a representation of a heredoc-style block with
  * key attributes common in configuration or scripting contexts.
- *
+ * <p>
  * This class is immutable and uses fluent accessors for its properties.
  */
 @Value

--- a/src/main/java/org/openrewrite/docker/internal/Heredoc.java
+++ b/src/main/java/org/openrewrite/docker/internal/Heredoc.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/Heredoc.java
+++ b/src/main/java/org/openrewrite/docker/internal/Heredoc.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * Represents a Heredoc structure in the context of defining content using
+ * a unique indicator, name, and optional redirection target.
+ *
+ * The Heredoc class provides a representation of a heredoc-style block with
+ * key attributes common in configuration or scripting contexts.
+ *
+ * This class is immutable and uses fluent accessors for its properties.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+@Accessors(fluent = true)
+public class Heredoc {
+    String indicator;
+    String name;
+    String redirectionTo;
+}

--- a/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
+++ b/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.internal.parsers.*;
+
+import java.util.List;
+
+/**
+ * Registry for instruction parsers.
+ * This class is responsible for managing and providing access to different instruction parsers.
+ */
+public class InstructionParserRegistry implements ParserRegistry {
+
+    private final List<InstructionParser> parsers = List.of(
+            new FromInstructionParser(),
+            new RunInstructionParser(),
+            new OnBuildInstructionParser(this),
+            new AddInstructionParser(),
+            new CmdInstructionParser(),
+            new CommentParser(),
+            new ArgInstructionParser(),
+            new LabelInstructionParser(),
+            new StopSignalInstructionParser(),
+            new ExposeInstructionParser(),
+            new MaintainerInstructionParser(),
+            new HealthcheckInstructionParser(),
+            new EnvInstructionParser(),
+            new CopyInstructionParser(),
+            new EntrypointInstructionParser(),
+            new VolumeInstructionParser(),
+            new WorkdirInstructionParser(),
+            new ShellInstructionParser(),
+            new UserInstructionParser(),
+            new UnknownInstruction()
+    );
+
+
+    public InstructionParser getParserFor(String keyword) {
+        return parsers.stream()
+                .filter(p -> p.supports(keyword))
+                .findFirst()
+                .orElse(new UnknownInstruction());
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
+++ b/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
@@ -16,6 +16,7 @@ package org.openrewrite.docker.internal;
 
 import org.openrewrite.docker.internal.parsers.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -24,7 +25,7 @@ import java.util.List;
  */
 public class InstructionParserRegistry implements ParserRegistry {
 
-    private final List<InstructionParser> parsers = List.of(
+    private final List<InstructionParser> parsers = Arrays.asList(
             new FromInstructionParser(),
             new RunInstructionParser(),
             new OnBuildInstructionParser(this),

--- a/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
+++ b/src/main/java/org/openrewrite/docker/internal/InstructionParserRegistry.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/ParserConstants.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+public abstract class ParserConstants {
+    private ParserConstants() {
+    }
+
+    static final String DOUBLE_QUOTE = "\"";
+    static final String SINGLE_QUOTE = "'";
+    static final String TAB = "\t";
+    static final String NEWLINE = "\n";
+    static final String EQUAL = "=";
+    static final String SPACE = " ";
+    static final String EMPTY = "";
+    static final String COMMA = ",";
+
+    public static final String SHELL = "SHELL";
+    public static final String ARG = "ARG";
+    public static final String FROM = "FROM";
+    public static final String MAINTAINER = "MAINTAINER";
+    public static final String RUN = "RUN";
+    public static final String CMD = "CMD";
+    public static final String ENTRYPOINT = "ENTRYPOINT";
+    public static final String ENV = "ENV";
+    public static final String ADD = "ADD";
+    public static final String COPY = "COPY";
+    public static final String VOLUME = "VOLUME";
+    public static final String EXPOSE = "EXPOSE";
+    public static final String USER = "USER";
+    public static final String WORKDIR = "WORKDIR";
+    public static final String LABEL = "LABEL";
+    public static final String STOPSIGNAL = "STOPSIGNAL";
+    public static final String HEALTHCHECK = "HEALTHCHECK";
+    public static final String ONBUILD = "ONBUILD";
+    public static final String COMMENT = "#";
+}

--- a/src/main/java/org/openrewrite/docker/internal/ParserConstants.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserConstants.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/ParserState.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserState.java
@@ -14,10 +14,10 @@
  */
 package org.openrewrite.docker.internal;
 
-import org.openrewrite.docker.tree.Space;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.openrewrite.docker.tree.Space;
 
 @Getter
 @Setter

--- a/src/main/java/org/openrewrite/docker/internal/ParserState.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserState.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.Space;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(fluent = true)
+public class ParserState {
+    private Space prefix = Space.EMPTY;
+    private Space rightPadding = Space.EMPTY;
+    private char escapeChar = '\\';
+    private boolean isContinuation = false;
+    private Heredoc heredoc = null;
+
+    public void reset() {
+        prefix = Space.EMPTY;
+        rightPadding = Space.EMPTY;
+        escapeChar = '\\';
+        isContinuation = false;
+        heredoc = null;
+    }
+
+    String getEscapeString() {
+        return String.valueOf(escapeChar);
+    }
+
+    void appendPrefix(Space prefix) {
+        if (prefix != null) {
+            this.prefix = prefix.withWhitespace(this.prefix.getWhitespace() + prefix.getWhitespace());
+        }
+    }
+
+    void resetPrefix() {
+        prefix = Space.EMPTY;
+    }
+
+    ParserState copy() {
+        ParserState copy = new ParserState();
+        copy.prefix = this.prefix;
+        copy.rightPadding = this.rightPadding;
+        copy.escapeChar = this.escapeChar;
+        copy.isContinuation = this.isContinuation;
+        copy.heredoc = this.heredoc;
+        return copy;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/ParserState.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserState.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/ParserUtils.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserUtils.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/ParserUtils.java
+++ b/src/main/java/org/openrewrite/docker/internal/ParserUtils.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.*;
+import org.openrewrite.internal.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.openrewrite.docker.internal.ParserConstants.*;
+
+public class ParserUtils {
+    public static Docker.Port stringToPorts(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        StringWithPadding stringWithPadding = StringWithPadding.of(s);
+        String content = stringWithPadding.content();
+        String[] parts = content.split("/");
+
+        if (parts.length == 2) {
+            return new Docker.Port(stringWithPadding.prefix(), parts[0], parts[1], true);
+        } else if (parts.length == 1) {
+            return new Docker.Port(stringWithPadding.prefix(), parts[0], "tcp", false);
+        }
+        return null;
+    }
+
+    public static Docker.KeyArgs stringToKeyArgs(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+
+        StringWithPadding stringWithPadding = StringWithPadding.of(s);
+        String content = stringWithPadding.content();
+
+        @SuppressWarnings("RegExpRepeatedSpace")
+        String delim = content.contains(EQUAL) ? EQUAL : SPACE;
+        String[] parts = content.split(delim, EQUAL.equals(delim) ? 2 : 0);
+        String key = parts.length > 0 ? parts[0] : EMPTY;
+        String value = parts.length > 1 ? parts[1].trim() : null;
+        Quoting q = Quoting.UNQUOTED;
+
+        if (value != null) {
+            if (value.startsWith(DOUBLE_QUOTE) && value.endsWith(DOUBLE_QUOTE)) {
+                q = Quoting.DOUBLE_QUOTED;
+                value = value.substring(1, value.length() - 1);
+            } else if (value.startsWith(SINGLE_QUOTE) && value.endsWith(SINGLE_QUOTE)) {
+                q = Quoting.SINGLE_QUOTED;
+                value = value.substring(1, value.length() - 1);
+            }
+        }
+        return new Docker.KeyArgs(stringWithPadding.prefix(), Docker.Literal.build(key), Docker.Literal.build(value), EQUAL.equals(delim), q);
+    }
+
+    public static <T> List<DockerRightPadded<T>> parseElements(String input, String delims, boolean appendRightPadding, ParserState state, Function<String, T> elementCreator) {
+        List<DockerRightPadded<T>> elements = new ArrayList<>();
+        StringBuilder currentElement = new StringBuilder();
+        StringBuilder afterBuilder = new StringBuilder(); // queue up escaped newlines and whitespace as 'after' for previous element
+
+        // inCollectible is used to accumulate elements within surrounding characters like single/double quotes, parentheses, etc.
+        boolean inCollectible = false;
+        char doubleQuote = DOUBLE_QUOTE.charAt(0);
+        char singleQuote = SINGLE_QUOTE.charAt(0);
+        char bracketOpen = '(';
+        char bracketClose = ')';
+        char braceOpen = '{';
+        char braceClose = '}';
+        char squareBracketOpen = '[';
+        char squareBracketClose = ']';
+        char escape = state.escapeChar();
+        char quote = 0;
+        char lastChar = 0;
+        char comma = ',';
+
+        // create a lookup of chars from delims
+        HashSet<Character> delimSet = new HashSet<>();
+        for (char c : delims.toCharArray()) {
+            delimSet.add(c);
+        }
+
+        boolean inHeredoc = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (inCollectible) {
+                if ((c == quote || c == bracketClose || c == braceClose || c == squareBracketClose) && lastChar != escape) {
+                    inCollectible = false;
+                }
+                currentElement.append(c);
+            } else {
+                if (delimSet.contains(c) && (lastChar != escape || (inHeredoc && c == '\n'))) {
+                    if (!StringUtils.isBlank(currentElement.toString())) {
+                        elements.add(DockerRightPadded.build(elementCreator.apply(currentElement.toString()))
+                                .withAfter(Space.EMPTY));
+                        currentElement.setLength(0);
+                    }
+                    // drop comma, assuming we are creating a list of elements
+                    if (c != comma) {
+                        currentElement.append(c);
+                    }
+                } else {
+                    if (c == doubleQuote || c == singleQuote || c == bracketOpen || c == braceOpen || c == squareBracketOpen) {
+                        inCollectible = true;
+                        quote = c;
+                    }
+
+                    Heredoc heredoc = state.heredoc();
+                    if (inHeredoc && !elements.isEmpty() && elements.get(elements.size() - 1).getElement() instanceof Docker.Literal) {
+                        Docker.Literal literal = (Docker.Literal) elements.get(elements.size() - 1).getElement();
+                        // allows commands to come after a heredoc. Does not support heredoc within a heredoc or multiple heredocs
+
+                        if (literal.getText() != null && heredoc != null && literal.getText().equals(heredoc.name())) {
+                            inHeredoc = false;
+                        }
+                    }
+
+                    // Check if within a heredoc and set escape character to '\n'
+                    if (heredoc != null && c == '\n' && !inHeredoc) {
+                        inHeredoc = true;
+                        afterBuilder.append(c);
+                        if (currentElement.length() > 0 && (
+                                currentElement.toString().endsWith(heredoc.indicator()) || (heredoc.redirectionTo() != null && currentElement.toString().endsWith(heredoc.redirectionTo())))) {
+                            elements.add(DockerRightPadded.build(elementCreator.apply(currentElement.toString()))
+                                    .withAfter(Space.build(afterBuilder.toString())));
+                            currentElement.setLength(0);
+                            afterBuilder.setLength(0);
+                        }
+
+                        lastChar = c;
+                        continue;
+                    } else //noinspection ConstantValue
+                        if (heredoc != null && c == '\n' && inHeredoc) {
+                            // IntelliJ incorrectly flags inHeredoc as a constant 'true', but it's obviously not.
+                            if (!currentElement.toString().endsWith(heredoc.indicator())) {
+                                afterBuilder.append(c);
+                                // this check allows us to accumulate "after" newlines and whitespace after for the last element
+                                if (currentElement.length() > 0) {
+                                    elements.add(DockerRightPadded.build(elementCreator.apply(currentElement.toString()))
+                                            .withAfter(Space.build(afterBuilder.toString())));
+                                    currentElement.setLength(0);
+                                    afterBuilder.setLength(0);
+                                }
+
+                                lastChar = c;
+                                continue;
+                            }
+
+                            // if we have a heredoc name, we are done with the heredoc
+                            inHeredoc = false;
+                        }
+
+                    // "peek": if the current character is an escape and the next character is newline or carriage return, 'after' and advance
+                    int nextCharIndex = i + 1;
+                    if (c == escape && nextCharIndex < input.length() && (input.charAt(nextCharIndex) == '\n' || input.charAt(nextCharIndex) == '\r')) {
+                        // if we had already collected some whitespace (only whitespace), add it as 'after' to the last element
+                        if (StringUtils.isBlank(currentElement.toString())) {
+                            afterBuilder.append(currentElement);
+                            currentElement.setLength(0);
+                        }
+
+                        char next = input.charAt(nextCharIndex);
+                        afterBuilder.append(escape).append(next);
+
+                        // manually advance
+                        lastChar = next;
+                        i++;
+                        continue;
+                    }
+
+                    // if 'after' builder is not empty and the character is whitespace, accumulate it
+                    if (afterBuilder.length() > 0 && (c == ' ' || c == '\t' || c == '\n')) {
+                        afterBuilder.append(c);
+                        lastChar = c;
+                        continue;
+                    }
+
+                    // Drop escape character if it is followed by a space
+                    // other situations will retain the escape character
+                    if (lastChar == escape && c == ' ') {
+                        currentElement.setLength(currentElement.length() - 1);
+                    }
+
+                    // no longer accumulating a prefix, add as "after" to the last element
+                    if (!elements.isEmpty() && afterBuilder.length() > 0) {
+                        int idx = elements.size() - 1;
+                        DockerRightPadded<T> element = elements.get(idx);
+                        elements.set(idx, element.withAfter(Space.append(element.getAfter(), Space.build(afterBuilder.toString()))));
+                        afterBuilder.setLength(0);
+                    }
+
+                    // Only collect the current element if we're not "in a prefix" situation
+                    if (afterBuilder.length() == 0) {
+                        currentElement.append(c);
+                    }
+                }
+            }
+            lastChar = c;
+        }
+
+        if (currentElement.length() > 0) {
+            // if it's whitespace only, add it as "after" to the last element
+            if (StringUtils.isBlank(currentElement.toString())) {
+                if (!elements.isEmpty()) {
+                    int idx = elements.size() - 1;
+                    elements.set(idx, elements.get(idx).withAfter(Space.build(currentElement.toString())));
+                }
+            } else {
+                DockerRightPadded<T> element = DockerRightPadded.build(elementCreator.apply(currentElement.toString()));
+                if (appendRightPadding) {
+                    element = element.withAfter(state.rightPadding());
+                }
+                elements.add(element);
+            }
+        }
+
+        if (afterBuilder.length() > 0) {
+            int idx = elements.size() - 1;
+            if (idx >= 0) {
+                DockerRightPadded<T> element = elements.get(idx);
+                elements.set(idx, element.withAfter(Space.append(element.getAfter(), Space.build(afterBuilder.toString()))));
+            }
+        }
+
+        return elements;
+    }
+
+    public static List<DockerRightPadded<Docker.Port>> parsePorts(String input, ParserState state) {
+        return parseElements(input, SPACE + TAB, true, state, ParserUtils::stringToPorts);
+    }
+
+    public static List<DockerRightPadded<Docker.KeyArgs>> parseArgs(String input, ParserState state) {
+        return parseElements(input, SPACE + TAB, true, state, ParserUtils::stringToKeyArgs);
+    }
+
+    public static List<DockerRightPadded<Docker.Literal>> parseLiterals(String input, ParserState state) {
+        return parseElements(input, SPACE, true, state, ParserUtils::createLiteral);
+    }
+
+    public static List<DockerRightPadded<Docker.Literal>> parseLiterals(Form form, String input, ParserState state) {
+        // appendRightPadding is true for shell form, false for exec form
+        // exec form is a JSON array, so we need to parse it differently where right padding is after the ']'.
+        return parseElements(input, form == Form.EXEC ? COMMA : SPACE, form == Form.SHELL, state, ParserUtils::createLiteral);
+    }
+
+    public static Docker.Literal createLiteral(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        StringWithPadding stringWithPadding = StringWithPadding.of(s);
+        String content = stringWithPadding.content();
+        Quoting q = Quoting.UNQUOTED;
+        if (content.startsWith(DOUBLE_QUOTE) && content.endsWith(DOUBLE_QUOTE)) {
+            q = Quoting.DOUBLE_QUOTED;
+            content = content.substring(1, content.length() - 1);
+        } else if (content.startsWith(SINGLE_QUOTE) && content.endsWith(SINGLE_QUOTE)) {
+            q = Quoting.SINGLE_QUOTED;
+            content = content.substring(1, content.length() - 1);
+        }
+        return Docker.Literal.build(
+                q, stringWithPadding.prefix(),
+                content,
+                stringWithPadding.suffix()
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/StringUtil.java
+++ b/src/main/java/org/openrewrite/docker/internal/StringUtil.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/StringUtil.java
+++ b/src/main/java/org/openrewrite/docker/internal/StringUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.jspecify.annotations.NonNull;
+
+public class StringUtil {
+    private StringUtil() {
+    }
+
+    public static @NonNull String trimDoubleQuotes(String text) {
+        return trim(text, "\"");
+    }
+
+    public static @NonNull String trimSingleQuotes(String text) {
+        return trim(text, "'");
+    }
+
+    public static @NonNull String trim(String text, String cutset) {
+        if (text != null && text.length() > 1 && text.startsWith(cutset) && text.endsWith(cutset)) {
+            text = text.substring(1, text.length() - 1);
+        }
+        return text == null ? "" : text;
+    }
+
+    public static @NonNull String trim(String text, String prefix, String suffix) {
+        if (text.startsWith(prefix) && text.endsWith(suffix)) {
+            text = text.substring(prefix.length(), text.length() - suffix.length());
+        }
+        return text;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
+++ b/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal;
 
-import org.openrewrite.docker.tree.Space;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
+import org.openrewrite.docker.tree.Space;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
+++ b/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.Space;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+@Accessors(fluent = true)
+public class StringWithPadding {
+    String content;
+    Space prefix;
+    Space suffix;
+
+    public static StringWithPadding of(String value) {
+        if (value == null || value.isEmpty()) {
+            return new StringWithPadding("", Space.EMPTY, Space.EMPTY);
+        }
+
+        int idx = 0;
+        for (char c : value.toCharArray()) {
+            if (c == ' ' || c == '\t') {
+                idx++;
+            } else {
+                break;
+            }
+        }
+
+        if (idx == value.length()) {
+            return new StringWithPadding("", Space.build(value), Space.EMPTY);
+        }
+
+        Space rightPadding = Space.EMPTY;
+        Space before = Space.build(value.substring(0, idx));
+        value = value.substring(idx);
+
+        idx = value.length() - 1;
+        // walk line backwards to find the last non-whitespace character
+        for (int i = value.length() - 1; i >= 0; i--) {
+            if (value.charAt(i) != ' ' && value.charAt(i) != '\t') {
+                // move the pointer to after the current non-whitespace character
+                idx = i + 1;
+                break;
+            }
+        }
+
+        if (idx < value.length()) {
+            rightPadding = Space.build(value.substring(idx));
+            value = value.substring(0, idx);
+        }
+
+        return new StringWithPadding(value, before, rightPadding);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
+++ b/src/main/java/org/openrewrite/docker/internal/StringWithPadding.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+public class AddInstructionParser extends AddLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "ADD";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        return new Docker.Add(
+                Tree.randomId(),
+                state.prefix(),
+                elements.getOptions(),
+                elements.getSources(),
+                elements.getDestination(),
+                Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
@@ -14,10 +14,10 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 public class AddInstructionParser extends AddLikeInstructionParser {

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import lombok.Getter;
+import lombok.Value;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.docker.internal.ParserUtils.stringToKeyArgs;
+
+public abstract class AddLikeInstructionParser implements InstructionParser {
+    @Value
+    @Getter
+    static class Elements {
+        List<Docker.Option> options;
+        List<Docker.Literal> sources;
+        Docker.Literal destination;
+    }
+
+    protected Elements parseElements(String content, ParserState state) {
+        // TODO: COPY allows for heredoc with redirection, but ADD does not
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(content, state);
+
+        List<Docker.Option> options = new ArrayList<>();
+        List<Docker.Literal> sources = new ArrayList<>();
+        Docker.Literal destination = null;
+
+        // reverse literals iteration
+        for (int i = literals.size() - 1; i >= 0; i--) {
+            DockerRightPadded<Docker.Literal> literal = literals.get(i);
+            // hack: if we have a heredoc, it'll all become the "sources"
+            if (state.heredoc() == null && i == literals.size() - 1) {
+                // the last literal is the destination
+                destination = literal.getElement().withTrailing(Space.append(literal.getElement().getTrailing(), literal.getAfter()));
+                continue;
+            }
+
+            if (i == 0 && literal.getElement().getPrefix().isEmpty()) {
+                literal = literal.map(e -> e.withPrefix(state.prefix()));
+            }
+
+            String value = literal.getElement().getText();
+            if (value.startsWith("--")) {
+                options.add(0, new Docker.Option(
+                        Tree.randomId(),
+                        literal.getElement().getPrefix(),
+                        stringToKeyArgs(literal.getElement().getText()),
+                        Markers.EMPTY, literal.getAfter()));
+            } else {
+                sources.add(0, literal.getElement().withTrailing(Space.append(literal.getElement().getTrailing(), literal.getAfter())));
+            }
+        }
+
+        return new Elements(options, sources, destination);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
@@ -14,14 +14,14 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import lombok.Getter;
+import lombok.Value;
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import lombok.Getter;
-import lombok.Value;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/AddLikeInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class ArgInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "ARG";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        List<DockerRightPadded<Docker.KeyArgs>> args = ParserUtils.parseArgs(line, state);
+        return new Docker.Arg(Tree.randomId(), state.prefix(), args, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ArgInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CmdInstructionParser.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CmdInstructionParser extends CommandLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "CMD";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(elements.getForm(), elements.getContent(), state);
+
+        return new Docker.Cmd(Tree.randomId(), elements.getForm(), state.prefix(), elements.getExecFormPrefix(),
+                literals.stream()
+                        .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                        .collect(Collectors.toList()),
+                elements.getExecFormSuffix(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.Form;
+import org.openrewrite.docker.tree.Space;
+import lombok.Getter;
+import lombok.Value;
+
+abstract class CommandLikeInstructionParser implements InstructionParser {
+    @Value
+    @Getter
+    static class Elements {
+        String content;
+        Form form;
+        Space execFormPrefix;
+        Space execFormSuffix;
+    }
+
+    protected Elements parseElements(String content, ParserState state) {
+        Form form = Form.SHELL;
+        Space execFormPrefix = Space.EMPTY;
+        Space execFormSuffix = Space.EMPTY;
+        if (content.trim().startsWith("[")) {
+            StringWithPadding stringWithPadding = StringWithPadding.of(content);
+            content = stringWithPadding.content();
+            execFormPrefix = stringWithPadding.prefix();
+            content = content.substring(1, content.length() - 1);
+            form = Form.EXEC;
+
+            execFormSuffix = state.rightPadding();
+        }
+        return new Elements(content, form, execFormPrefix, execFormSuffix);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommandLikeInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import lombok.Getter;
+import lombok.Value;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.StringWithPadding;
 import org.openrewrite.docker.tree.Form;
 import org.openrewrite.docker.tree.Space;
-import lombok.Getter;
-import lombok.Value;
 
 abstract class CommandLikeInstructionParser implements InstructionParser {
     @Value

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class CommentParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        // a special case where we treat a comment as an instruction
+        return "#";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        StringWithPadding stringWithPadding = StringWithPadding.of(line);
+
+        String lower = stringWithPadding.content().toLowerCase();
+        if ((lower.startsWith("syntax=") || lower.startsWith("escape=") || lower.startsWith("check=")) && !lower.contains(" ")) {
+            List<DockerRightPadded<Docker.KeyArgs>> args = ParserUtils.parseArgs(line, state);
+            DockerRightPadded<Docker.KeyArgs> directive = args.get(0);
+            if (directive.getElement().getKey().getText().equalsIgnoreCase("escape")) {
+                state.escapeChar(directive.getElement().getValue().getText().charAt(0));
+            }
+
+            return new Docker.Directive(Tree.randomId(), state.prefix(), args.get(0), Markers.EMPTY, Space.EMPTY);
+        }
+
+        Docker.Literal commentLiteral = ParserUtils.createLiteral(stringWithPadding.content());
+        if (commentLiteral == null) {
+            // if the comment is empty, we need to create a literal with an empty string
+            commentLiteral = Docker.Literal.build(
+                    Quoting.UNQUOTED,
+                    Space.EMPTY,
+                    "",
+                    Space.EMPTY);
+        }
+        commentLiteral = commentLiteral.withPrefix(stringWithPadding.prefix());
+
+        return new Docker.Comment(
+                Tree.randomId(),
+                state.prefix(),
+                commentLiteral.withTrailing(Space.append(commentLiteral.getTrailing(), state.rightPadding())),
+                Markers.EMPTY,
+                Space.EMPTY
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
@@ -14,6 +14,7 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.internal.StringWithPadding;
@@ -21,7 +22,6 @@ import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CommentParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+public class CopyInstructionParser extends AddLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "COPY";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+        return new Docker.Copy(
+                Tree.randomId(),
+                state.prefix(),
+                elements.getOptions(),
+                elements.getSources(),
+                elements.getDestination(),
+                Markers.EMPTY,
+                Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/CopyInstructionParser.java
@@ -14,10 +14,10 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 public class CopyInstructionParser extends AddLikeInstructionParser {

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EntrypointInstructionParser extends CommandLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "ENTRYPOINT";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(elements.getForm(), elements.getContent(), state);
+        return new Docker.Entrypoint(Tree.randomId(), elements.getForm(), state.prefix(), elements.getExecFormPrefix(),
+                literals.stream()
+                        .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                        .collect(Collectors.toList()), elements.getExecFormSuffix(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EntrypointInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnvInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "ENV";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        List<DockerRightPadded<Docker.KeyArgs>> args = ParserUtils.parseArgs(line, state);
+        // HACK: generally we have ENV key=value syntax. But we are going to post-process here to work out the alternate syntax.
+        //
+        // For ENV instruction in Docker, if the first key has no value (no equals sign),
+        // then everything that follows is considered the value for that key
+        //
+        // From Docker's documentation:
+        // This syntax does not allow for multiple environment-variables to be set in a single ENV instruction, and
+        // can be confusing. For example, the following sets a single environment variable (ONE) with value "TWO= THREE=world":
+        //
+        // ENV ONE TWO= THREE=world
+        List<DockerRightPadded<Docker.KeyArgs>> processedArgs = new ArrayList<>();
+
+        if (!args.isEmpty() && args.get(0).getElement().getValue().getText() == null) {
+            Docker.KeyArgs firstKey = args.get(0).getElement();
+
+            // The rest of the args (if any) should be combined as the value for the first key
+            if (args.size() > 1) {
+                StringBuilder combinedValue = getCombinedValue(args);
+                Docker.KeyArgs updatedFirstKey = Docker.KeyArgs.build(firstKey.key(),combinedValue.toString()).withHasEquals(false);
+                processedArgs.add(args.get(0).withElement(updatedFirstKey));
+            } else {
+                // If there are no other args, keep the first one as is
+                processedArgs.add(args.get(0));
+            }
+        } else {
+            // Standard key=value syntax, keep the args as they are
+            processedArgs.addAll(args);
+        }
+
+        return new Docker.Env(Tree.randomId(), state.prefix(), processedArgs, Markers.EMPTY, Space.EMPTY);
+    }
+
+    private static @NotNull StringBuilder getCombinedValue(List<DockerRightPadded<Docker.KeyArgs>> args) {
+        StringBuilder combinedValue = new StringBuilder();
+        for (int i = 1; i < args.size(); i++) {
+            Docker.KeyArgs keyArg = args.get(i).getElement();
+            if (i > 1) {
+                String space = keyArg.getKey().getPrefix().getWhitespace();
+                combinedValue.append(!space.isEmpty() ? space : " ");
+            }
+            combinedValue.append(keyArg.getKey().getText());
+            if (keyArg.getValue().getText() != null) {
+                if (keyArg.isHasEquals()) {
+                    combinedValue.append("=");
+                }
+                combinedValue.append(keyArg.getValue().getPrefix().getWhitespace());
+                combinedValue.append(keyArg.getValue().getText());
+            }
+        }
+        return combinedValue;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
@@ -14,13 +14,13 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.jetbrains.annotations.NotNull;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
@@ -53,7 +53,7 @@ public class EnvInstructionParser implements InstructionParser {
             // The rest of the args (if any) should be combined as the value for the first key
             if (args.size() > 1) {
                 StringBuilder combinedValue = getCombinedValue(args);
-                Docker.KeyArgs updatedFirstKey = Docker.KeyArgs.build(firstKey.key(),combinedValue.toString()).withHasEquals(false);
+                Docker.KeyArgs updatedFirstKey = Docker.KeyArgs.build(firstKey.key(), combinedValue.toString()).withHasEquals(false);
                 processedArgs.add(args.get(0).withElement(updatedFirstKey));
             } else {
                 // If there are no other args, keep the first one as is

--- a/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/EnvInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class ExposeInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "EXPOSE";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        List<DockerRightPadded<Docker.Port>> ports = ParserUtils.parsePorts(line, state);
+        return new Docker.Expose(Tree.randomId(), state.prefix(), ports, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ExposeInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
@@ -14,13 +14,13 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class FromInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "FROM";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Docker.Literal platform = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, null, Space.EMPTY);
+        Docker.Literal image = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, null, Space.EMPTY);
+        Docker.Literal version = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, null, Space.EMPTY);
+        Docker.Literal as = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, null, Space.EMPTY);
+        Docker.Literal alias = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, null, Space.EMPTY);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(line, state);
+        if (!literals.isEmpty()) {
+            while (!literals.isEmpty()) {
+                DockerRightPadded<Docker.Literal> literal = literals.remove(0);
+                Docker.Literal elem = literal.getElement();
+                String value = literal.getElement().getText();
+                Space after = Space.append(elem.getTrailing(), literal.getAfter());
+                if (value.startsWith("--platform")) {
+                    platform = elem.withTrailing(after);
+                } else if (image.getText() != null && "as".equalsIgnoreCase(value)) {
+                    as = elem.withTrailing(after);
+                } else if ("as".equalsIgnoreCase(as.getText())) {
+                    alias = elem.withTrailing(after);
+                } else if (image.getText() == null) {
+                    image = elem.withTrailing(after);
+                    String imageText = literal.getElement().getText();
+                    // walk imageText forwards to find the first ':' or '@' to determine the version
+                    int idx = 0;
+                    for (char c : imageText.toCharArray()) {
+                        if (c == ':' || c == '@') {
+                            break;
+                        }
+                        idx++;
+                    }
+
+                    if (idx < imageText.length() - 1) {
+                        version = ParserUtils.createLiteral(imageText.substring(idx))
+                                .withPrefix(Space.EMPTY)
+                                .withTrailing(image.getTrailing());
+                        imageText = imageText.substring(0, idx);
+
+                        String img = imageText;
+                        image = image.withText(img).withTrailing(Space.EMPTY);
+                    }
+                }
+            }
+        }
+
+        return new Docker.From(Tree.randomId(), state.prefix(), platform, image, version, as, alias, state.rightPadding(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/FromInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.*;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HealthcheckInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "HEALTHCHECK";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        StringWithPadding stringWithPadding = StringWithPadding.of(line);
+        String content = stringWithPadding.content();
+        List<Docker.Literal> commands;
+        if (content.equalsIgnoreCase("NONE")) {
+            commands = new ArrayList<>();
+            Docker.Literal none = Docker.Literal.build(Quoting.UNQUOTED, stringWithPadding.prefix(), content, stringWithPadding.suffix());
+            commands.add(none.withTrailing(state.rightPadding()));
+            return new Docker.Healthcheck(Tree.randomId(), state.prefix(), Docker.Healthcheck.Type.NONE, null, commands, Markers.EMPTY, Space.EMPTY);
+        }
+
+        List<DockerRightPadded<Docker.KeyArgs>> args;
+        String[] parts = line.split("CMD", 2);
+        if (parts.length > 1) {
+            // the first part is the options, but keyargs don't support trailing spaces
+            StringWithPadding swp = StringWithPadding.of(parts[0]);
+            // HACK if swp is all whitespace, we'll ignore it for now
+            if (!swp.content().isEmpty()) {
+                args = ParserUtils.parseArgs(swp.prefix().getWhitespace() + swp.content(), state);
+            } else {
+                args = new ArrayList<>();
+            }
+
+            // the second part is the command, prefix it with any keyargs trailing whitespace
+            commands = ParserUtils.parseLiterals(Form.SHELL, swp.suffix().getWhitespace() + "CMD" + parts[1], state)
+                    .stream().map(d ->
+                            d.getElement()
+                                    .withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                    .collect(Collectors.toList());
+        } else {
+            args = new ArrayList<>();
+            commands = ParserUtils.parseLiterals(Form.SHELL, content, state)
+                    .stream().map(d ->
+                            d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                    .collect(Collectors.toList());
+        }
+
+        return new Docker.Healthcheck(Tree.randomId(), state.prefix(), Docker.Healthcheck.Type.CMD, args, commands, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
@@ -14,11 +14,11 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.internal.StringWithPadding;
 import org.openrewrite.docker.tree.*;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/HealthcheckInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
@@ -38,7 +38,9 @@ public interface InstructionParser {
      */
     default boolean supports(String keyword) {
         return keyword.equalsIgnoreCase(instructionName());
-    };
+    }
+
+    ;
 
     /**
      * Parses a line of a Dockerfile and transforms it into a Docker instruction object.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/InstructionParser.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.tree.Docker;
+
+/**
+ * Interface for parsing Dockerfile instructions.
+ * This interface defines methods to determine if a specific instruction
+ * is supported and to facilitate the parsing of that instruction.
+ */
+public interface InstructionParser {
+    /**
+     * Returns the name of the Dockerfile instruction that this parser supports.
+     *
+     * @return the name of the supported Dockerfile instruction.
+     */
+    String instructionName();
+
+    /**
+     * Determines if the provided keyword corresponds to a supported Dockerfile instruction.
+     *
+     * @param keyword the keyword to check for support.
+     * @return true if the keyword is supported, false otherwise.
+     */
+    default boolean supports(String keyword) {
+        return keyword.equalsIgnoreCase(instructionName());
+    };
+
+    /**
+     * Parses a line of a Dockerfile and transforms it into a Docker instruction object.
+     *
+     * @param line  the line of the Dockerfile to be parsed.
+     * @param state the current state of the parser which may influence how the line is interpreted.
+     * @return a Docker instruction object representing the parsed line.
+     */
+    Docker.Instruction parse(String line, ParserState state);
+
+    default String peekWord(String line) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+
+        int i = 0;
+        while (i < line.length() && (line.charAt(i) == ' ' || line.charAt(i) == '\t')) {
+            i++;
+        }
+
+        int start = i;
+        if (line.charAt(i) == '#') {
+            i++;
+        } else {
+            while (i < line.length() && Character.isLetter(line.charAt(i))) {
+                i++;
+            }
+        }
+
+        return line.substring(start, i);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class LabelInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "LABEL";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        List<DockerRightPadded<Docker.KeyArgs>> args = ParserUtils.parseArgs(line, state);
+        return new Docker.Label(Tree.randomId(), state.prefix(), args, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/LabelInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.StringWithPadding;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 public class MaintainerInstructionParser implements InstructionParser {

--- a/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/MaintainerInstructionParser.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Quoting;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+public class MaintainerInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "MAINTAINER";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        // TODO: quoting
+        Quoting quoting = Quoting.UNQUOTED;
+        StringWithPadding stringWithPadding = StringWithPadding.of(line);
+        return new Docker.Maintainer(Tree.randomId(), quoting, state.prefix(),
+                Docker.Literal.build(stringWithPadding.content())
+                        .withPrefix(stringWithPadding.prefix())
+                        .withTrailing(Space.append(stringWithPadding.suffix(), state.rightPadding())),
+                Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
@@ -14,11 +14,11 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.StringWithPadding;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 

--- a/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/OnBuildInstructionParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+
+public class OnBuildInstructionParser implements InstructionParser {
+    private final ParserRegistry registry;
+
+    public OnBuildInstructionParser(ParserRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public String instructionName() {
+        return "ONBUILD";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        StringWithPadding stringWithPadding = StringWithPadding.of(line);
+
+        String instruction = peekWord(stringWithPadding.content());
+        line = line.substring(stringWithPadding.prefix().getWhitespace().length() + instruction.length());
+        Docker nested = registry.getParserFor(instruction).parse(line, state);
+
+        return new Docker.OnBuild(Tree.randomId(), state.prefix(), nested, state.rightPadding(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ParserRegistry.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ParserRegistry.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ParserRegistry.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ParserRegistry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+public interface ParserRegistry {
+    InstructionParser getParserFor(String keyword);
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.docker.internal.ParserUtils.stringToKeyArgs;
+
+public class RunInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "RUN";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        // TODO: Run allows for JSON array syntax (exec form)
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(line, state);
+        List<Docker.Option> options = new ArrayList<>();
+        List<Docker.Literal> commands = new ArrayList<>();
+
+        boolean doneWithOptions = false;
+        for (DockerRightPadded<Docker.Literal> literal : literals) {
+            String value = literal.getElement().getText();
+            if (!doneWithOptions && (value.startsWith("--mount") || value.startsWith("--network") || value.startsWith("--security"))) {
+                options.add(new Docker.Option(
+                        Tree.randomId(),
+                        literal.getElement().getPrefix(),
+                        stringToKeyArgs(literal.getElement().getText()),
+                        Markers.EMPTY, literal.getAfter()));
+            } else {
+                doneWithOptions = true;
+                commands.add(literal.getElement().withTrailing(Space.append(literal.getElement().getTrailing(), literal.getAfter())));
+            }
+        }
+
+        return new Docker.Run(Tree.randomId(), state.prefix(), options, commands, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/RunInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShellInstructionParser extends CommandLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "SHELL";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(elements.getForm(), elements.getContent(), state);
+        return new Docker.Shell(Tree.randomId(),
+                state.prefix(),
+                elements.getExecFormPrefix(),
+                literals.stream()
+                        .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                        .collect(Collectors.toList()),
+                elements.getExecFormSuffix(),
+                Markers.EMPTY,
+                Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/ShellInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
@@ -14,13 +14,13 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/StopSignalInstructionParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class StopSignalInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "STOPSIGNAL";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        List<DockerRightPadded<Docker.KeyArgs>> args = ParserUtils.parseArgs(line.toString(), state);
+        Docker.Literal signal = null;
+        if (!args.isEmpty()) {
+            DockerRightPadded<Docker.KeyArgs> arg = args.get(0);
+            signal = Docker.Literal.build(Quoting.UNQUOTED, arg.getElement().getPrefix(), arg.getElement().key(), arg.getAfter());
+        }
+
+        return new Docker.StopSignal(Tree.randomId(), state.prefix(), signal, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/UnknownInstruction.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/UnknownInstruction.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/UnknownInstruction.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/UnknownInstruction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.tree.Docker;
+
+public class UnknownInstruction implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return null;
+    }
+
+    @Override
+    public boolean supports(String keyword) {
+        return true; // This parser supports all keywords
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        return null; // Return null or throw an exception as needed
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.StringWithPadding;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Quoting;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 

--- a/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.StringWithPadding;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Quoting;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+
+public class UserInstructionParser implements InstructionParser {
+    @Override
+    public String instructionName() {
+        return "USER";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        StringWithPadding stringWithPadding = StringWithPadding.of(line);
+        String[] parts = stringWithPadding.content().split(":", 2);
+
+        Docker.Literal user;
+        Docker.Literal group = null;
+        if (parts.length > 1) {
+            user = Docker.Literal.build(Quoting.UNQUOTED, stringWithPadding.prefix(), parts[0], Space.EMPTY);
+            group = Docker.Literal.build(Quoting.UNQUOTED, Space.EMPTY, parts[1], Space.append(stringWithPadding.suffix(), state.rightPadding()));
+        } else {
+            user = Docker.Literal.build(Quoting.UNQUOTED, stringWithPadding.prefix(), parts[0], Space.append(stringWithPadding.suffix(), state.rightPadding()));
+        }
+
+        return new Docker.User(Tree.randomId(), state.prefix(), user, group, Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/UserInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VolumeInstructionParser extends CommandLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "VOLUME";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(elements.getForm(), elements.getContent(), state);
+
+        return new Docker.Volume(Tree.randomId(), elements.getForm(), state.prefix(), elements.getExecFormPrefix(),
+                literals.stream()
+                        .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                        .collect(Collectors.toList()),
+                elements.getExecFormSuffix(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/VolumeInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal.parsers;
+
+import org.openrewrite.docker.internal.ParserState;
+import org.openrewrite.docker.internal.ParserUtils;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+public class WorkdirInstructionParser extends CommandLikeInstructionParser {
+    @Override
+    public String instructionName() {
+        return "WORKDIR";
+    }
+
+    @Override
+    public Docker.Instruction parse(String line, ParserState state) {
+        Elements elements = parseElements(line, state);
+
+        List<DockerRightPadded<Docker.Literal>> literals = ParserUtils.parseLiterals(elements.getForm(), elements.getContent(), state);
+
+        return new Docker.Workdir(Tree.randomId(), state.prefix(), literals.isEmpty() ? null : literals.get(0).getElement(), Markers.EMPTY, Space.EMPTY);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
+++ b/src/main/java/org/openrewrite/docker/internal/parsers/WorkdirInstructionParser.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.internal.parsers;
 
+import org.openrewrite.Tree;
 import org.openrewrite.docker.internal.ParserState;
 import org.openrewrite.docker.internal.ParserUtils;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Space;
-import org.openrewrite.Tree;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;

--- a/src/main/java/org/openrewrite/docker/package-info.java
+++ b/src/main/java/org/openrewrite/docker/package-info.java
@@ -16,5 +16,6 @@
 @NullMarked
 @NonNullFields
 package org.openrewrite.docker;
+
 import org.jspecify.annotations.NullMarked;
 import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/docker/table/ImageUseReport.java
+++ b/src/main/java/org/openrewrite/docker/table/ImageUseReport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class ImageUseReport extends DataTable<ImageUseReport.Row> {
+
+    public ImageUseReport(Recipe recipe) {
+        super(recipe,
+                "Image Use Report",
+                "Contains a report of the images used in the Dockerfile.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The path to the Dockerfile where the image is used.")
+        String sourcePath;
+
+        @Column(displayName = "Image Name",
+                description = "The name of the image used in the Dockerfile.")
+        String image;
+
+        @Column(displayName = "Image Tag",
+                description = "The tag of the image used in the Dockerfile.")
+        String tag;
+
+        @Column(displayName = "Image Digest",
+                description = "The digest of the image used in the Dockerfile.")
+        String digest;
+
+        @Column(displayName = "Image Platform",
+                description = "The platform of the image used in the Dockerfile.")
+        String platform;
+
+        @Column(displayName = "Image Alias",
+                description = "The alias of the image used in the Dockerfile.")
+        String alias;
+
+        @Column(displayName = "Stage Number",
+                description = "The stage number of the image used in the Dockerfile.")
+        Integer stageNumber;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/table/ImageUseReport.java
+++ b/src/main/java/org/openrewrite/docker/table/ImageUseReport.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/table/RemoteFileReport.java
+++ b/src/main/java/org/openrewrite/docker/table/RemoteFileReport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class RemoteFileReport extends DataTable<RemoteFileReport.Row> {
+    public RemoteFileReport(Recipe recipe) {
+        super(recipe,
+                "Remote File Report",
+                "Contains a report of the remote files used in the Dockerfile.");
+    }
+
+    @Value
+    @JsonIgnoreType
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The path to the Dockerfile where the remote file is used.")
+        String sourcePath;
+
+        @Column(displayName = "Remote File Path",
+                description = "The path to the remote file used in the Dockerfile.")
+        String url;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/table/RemoteFileReport.java
+++ b/src/main/java/org/openrewrite/docker/table/RemoteFileReport.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.trait;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jspecify.annotations.NonNull;
+import org.openrewrite.Cursor;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+
+import java.util.regex.Pattern;
+
+@Getter
+@AllArgsConstructor
+public class DockerLiteral implements Trait<Docker.@NonNull Literal> {
+    Cursor cursor;
+
+    public String getText() {
+        return getTree().getText();
+    }
+
+    public DockerLiteral withText(String newText) {
+        Docker.Literal literal = getTree().withText(newText);
+        cursor = new Cursor(cursor.getParent(), literal);
+        return this;
+    }
+
+    public static Matcher matcher(Pattern pattern) {
+        return new Matcher(pattern);
+    }
+
+    public static Matcher matcher(String pattern) {
+        return new Matcher(Pattern.compile(pattern));
+    }
+
+    public static class Matcher extends SimpleTraitMatcher<@NonNull DockerLiteral> {
+        private final Pattern pattern;
+
+        public Matcher(Pattern pattern) {
+            this.pattern = pattern;
+        }
+
+        @Override
+        protected DockerLiteral test(@NonNull Cursor cursor) {
+            if (pattern != null && cursor.getValue() instanceof Docker.Literal) {
+                String text = ((Docker.Literal) cursor.getValue()).getText();
+                if (text != null && pattern.matcher(text).matches()) {
+                    return new DockerLiteral(cursor);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
@@ -14,11 +14,11 @@
  */
 package org.openrewrite.docker.trait;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.jspecify.annotations.NonNull;
 import org.openrewrite.Cursor;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
 

--- a/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerLiteral.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/trait/DockerOption.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerOption.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.trait;
+
+import org.openrewrite.docker.tree.Docker;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.trait.SimpleTraitMatcher;
+import org.openrewrite.trait.Trait;
+
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
+public class DockerOption implements Trait<Docker.@NonNull Option> {
+    Cursor cursor;
+
+    public Docker.KeyArgs getArgs() {
+        return getTree().getKeyArgs();
+    }
+
+    public DockerOption withArgs(Docker.KeyArgs newArgs) {
+        Docker.Option option = getTree().withKeyArgs(newArgs);
+        cursor = new Cursor(cursor.getParent(), option);
+        return this;
+    }
+
+    public static Matcher matcher(String key, @Nullable String value, boolean regexMatch) {
+        return new Matcher(key, value, regexMatch);
+    }
+
+    public static class Matcher extends SimpleTraitMatcher<@NonNull DockerOption> {
+        private final String key;
+        private final String value;
+        private final boolean regexMatch;
+
+        public Matcher(String key, String value, boolean regexMatch) {
+            this.key = key;
+            this.value = value;
+            this.regexMatch = regexMatch;
+        }
+
+        @Override
+        protected DockerOption test(Cursor cursor) {
+            if (cursor.getValue() instanceof Docker.Option) {
+                Docker.Option option = cursor.getValue();
+                Docker.KeyArgs args = option.getKeyArgs();
+                Optional<String> key = Optional.ofNullable(args.key());
+                Optional<String> value = Optional.ofNullable(args.value());
+                if (this.regexMatch) {
+                    if (key.isPresent() && !key.get().matches(this.key) && !key.get().replaceFirst("--", "").matches(this.key)) {
+                        return null;
+                    }
+                    if (this.value != null && value.isPresent() && !value.get().matches(this.value)) {
+                        return null;
+                    }
+                } else {
+                    if (key.isPresent() && !key.get().equals(this.key)) {
+                        return null;
+                    }
+                    if (value.isPresent() && !value.get().equals(this.value)) {
+                        return null;
+                    }
+                }
+
+                return new DockerOption(cursor);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/docker/trait/DockerOption.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerOption.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/trait/DockerOption.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerOption.java
@@ -14,12 +14,12 @@
  */
 package org.openrewrite.docker.trait;
 
-import org.openrewrite.docker.tree.Docker;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
 

--- a/src/main/java/org/openrewrite/docker/trait/Traits.java
+++ b/src/main/java/org/openrewrite/docker/trait/Traits.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.trait;
+
+import java.util.regex.Pattern;
+
+public class Traits {
+    public static DockerLiteral.Matcher literal(String pattern) {
+        return new DockerLiteral.Matcher(pattern == null ? null : Pattern.compile(pattern));
+    }
+
+    public static DockerLiteral.Matcher literal(Pattern pattern) {
+        return new DockerLiteral.Matcher(pattern);
+    }
+
+    public static DockerOption.Matcher option(String key, String value, boolean regexMatch) {
+        return new DockerOption.Matcher(key, value, regexMatch);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/trait/Traits.java
+++ b/src/main/java/org/openrewrite/docker/trait/Traits.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -14,18 +14,20 @@
  */
 package org.openrewrite.docker.tree;
 
-import org.openrewrite.docker.DockerVisitor;
 import lombok.*;
 import lombok.experimental.NonFinal;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.Markers;
 
 import java.lang.ref.SoftReference;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -244,12 +246,12 @@ public interface Docker extends Tree {
 
         public static Document build(Instruction... instructions) {
             Stage stage = new Stage(Tree.randomId(), Arrays.stream(instructions).collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY);
-            return new Document(Tree.randomId(), Path.of("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
-                    List.of(stage), Space.EMPTY, Markers.EMPTY);
+            return new Document(Tree.randomId(), Paths.get("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
+                    Collections.singletonList(stage), Space.EMPTY, Markers.EMPTY);
         }
 
         public static Document build(List<Stage> stages) {
-            return new Document(Tree.randomId(), Path.of("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
+            return new Document(Tree.randomId(), Paths.get("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
                     stages, Space.EMPTY, Markers.EMPTY);
         }
 
@@ -331,7 +333,7 @@ public interface Docker extends Tree {
         }
 
         public static Arg build(String key, String value) {
-            return new Arg(Tree.randomId(), Space.EMPTY, List.of(
+            return new Arg(Tree.randomId(), Space.EMPTY, Collections.singletonList(
                     DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
             ), Markers.EMPTY, Space.NEWLINE);
         }
@@ -617,7 +619,7 @@ public interface Docker extends Tree {
         public static Env build(String key, String value) {
             return new Env(Tree.randomId(),
                     Space.EMPTY,
-                    List.of(
+                    Collections.singletonList(
                             DockerRightPadded.build(
                                     new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED)
                             )
@@ -791,7 +793,7 @@ public interface Docker extends Tree {
 
         public From alias(String alias) {
             From result = this;
-            if (this.as.getText() == null || this.as.getText().isBlank()) {
+            if (this.as.getText() == null || StringUtils.isBlank(this.as.getText())) {
                 result = result.withAs(Literal.build("AS").withPrefix(this.as.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
             }
             return result.withAlias(this.alias.withText(alias).withPrefix(this.alias.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
@@ -815,7 +817,7 @@ public interface Docker extends Tree {
                     Literal.build(null).withPrefix(Space.build(" ")),
                     Literal.build(null).withPrefix(Space.build(" ")),
                     Literal.build(null).withPrefix(Space.build(" ")),
-                    alias != null && !alias.isBlank() ? Literal.build("AS").withPrefix(Space.build(" ")) : null,
+                    alias != null && !StringUtils.isBlank(alias) ? Literal.build("AS").withPrefix(Space.build(" ")) : null,
                     Literal.build(alias).withPrefix(Space.build(" ")),
                     Space.EMPTY,
                     Markers.EMPTY,
@@ -901,7 +903,7 @@ public interface Docker extends Tree {
         }
 
         public static Label build(String key, String value) {
-            return new Label(Tree.randomId(), Space.EMPTY, List.of(
+            return new Label(Tree.randomId(), Space.EMPTY, Collections.singletonList(
                     DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
             ), Markers.EMPTY, Space.NEWLINE);
         }

--- a/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -1,0 +1,1339 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import org.openrewrite.docker.DockerVisitor;
+import lombok.*;
+import lombok.experimental.NonFinal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.marker.Markers;
+
+import java.lang.ref.SoftReference;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.docker.internal.StringUtil.trimDoubleQuotes;
+import static org.openrewrite.docker.internal.StringUtil.trimSingleQuotes;
+
+// TODO: maybe add helper methods to simplify setting of (most) fields?
+
+/**
+ * A Dockerfile AST.
+ */
+public interface Docker extends Tree {
+
+    interface Instruction extends Docker {
+        <T extends Tree> T withEol(Space eol);
+
+        Space getEol();
+    }
+
+
+    static boolean same(String first, String second) {
+        if (first == null && second == null) {
+            return true;
+        }
+        if (first == null || second == null) {
+            return false;
+        }
+        return first.equals(second);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <R extends Tree, P> R accept(TreeVisitor<R, P> v, P p) {
+        return (R) acceptDocker(v.adapt(DockerVisitor.class), p);
+    }
+
+    @Override
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v.isAdaptableTo(DockerVisitor.class);
+    }
+
+    @Nullable
+    default <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+        return v.defaultValue(this, p);
+    }
+
+    /**
+     * @return A copy of this Dockerfile with the same content, but with new ids.
+     */
+    Docker copyPaste();
+
+    default Space getPrefix() {
+        return Space.EMPTY;
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Literal implements Docker {
+        @EqualsAndHashCode.Include(rank = 0)
+        UUID id;
+
+        Quoting quoting;
+
+        Space prefix;
+
+        @EqualsAndHashCode.Include(rank = 1000)
+        String text;
+
+        Space trailing;
+
+        Markers markers;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitLiteral(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Literal(Tree.randomId(), quoting, prefix, text, trailing,
+                    markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()));
+        }
+
+        public static Literal build(String text) {
+            Quoting quoting = Quoting.UNQUOTED;
+            if (text != null && text.length() > 1) {
+                if (text.startsWith("'") && text.endsWith("'")) {
+                    text = trimSingleQuotes(text);
+                    quoting = Quoting.SINGLE_QUOTED;
+                } else if (text.startsWith("\"") && text.endsWith("\"")) {
+                    text = trimDoubleQuotes(text);
+                    quoting = Quoting.DOUBLE_QUOTED;
+                }
+            }
+            return new Literal(Tree.randomId(), quoting, Space.EMPTY, text, Space.EMPTY, Markers.EMPTY);
+        }
+
+        public static Literal prepend(String text, Literal literal) {
+            if (literal == null) {
+                return build(text);
+            }
+
+            if (text == null || text.isEmpty()) {
+                return literal;
+            }
+
+            return new Literal(Tree.randomId(), literal.getQuoting(), literal.getPrefix(), text + literal.getText(), literal.getTrailing(), literal.getMarkers());
+        }
+
+        public static Literal build(Quoting quoting, Space prefix, String text, Space trailing) {
+            return new Literal(Tree.randomId(), quoting, prefix, text, trailing, Markers.EMPTY);
+        }
+    }
+
+    /**
+     * A Dockerfile option, such as --platform or --chown.
+     * This is different from KeyArgs, which is intended to be a hashable key-value pair.
+     * We use Option to allow for key-value pairs which can be repeated (e.g. --exclude in COPY/ADD).
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Option implements Docker {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Space prefix;
+
+        KeyArgs keyArgs;
+
+        Markers markers;
+
+        Space trailing;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitOption(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Option(Tree.randomId(), prefix, keyArgs, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()), trailing);
+        }
+
+        public static Option build(String key, String value) {
+            return new Option(Tree.randomId(), Space.EMPTY, KeyArgs.build(key, value).withHasEquals(true), Markers.EMPTY, Space.EMPTY);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
+    class Document implements Docker, SourceFileWithReferences {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Path sourcePath;
+
+        @Nullable
+        FileAttributes fileAttributes;
+
+        @Nullable // for backwards compatibility
+        @With(AccessLevel.PRIVATE)
+        String charsetName;
+
+        boolean charsetBomMarked;
+
+        @Nullable
+        Checksum checksum;
+
+        List<Stage> stages;
+
+        Space eof;
+
+        Markers markers;
+
+        @Override
+        public Charset getCharset() {
+            return charsetName == null ? StandardCharsets.UTF_8 : Charset.forName(charsetName);
+        }
+
+        @Override
+        public SourceFile withCharset(Charset charset) {
+            return withCharsetName(charset.name());
+        }
+
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitDocument(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Document(Tree.randomId(), sourcePath, fileAttributes, charsetName, charsetBomMarked, checksum,
+                    stages.stream().map(Stage::copyPaste).collect(Collectors.toCollection(ArrayList::new)), eof, markers);
+        }
+
+        public static Document build(Instruction... instructions) {
+            Stage stage = new Stage(Tree.randomId(), Arrays.stream(instructions).collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY);
+            return new Document(Tree.randomId(), Path.of("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
+                    List.of(stage), Space.EMPTY, Markers.EMPTY);
+        }
+
+        public static Document build(List<Stage> stages) {
+            return new Document(Tree.randomId(), Path.of("Dockerfile"), null, StandardCharsets.UTF_8.name(), false, null,
+                    stages, Space.EMPTY, Markers.EMPTY);
+        }
+
+        @Nullable
+        @NonFinal
+        transient SoftReference<References> references;
+
+        @Override
+        public @NonNull References getReferences() {
+            this.references = build(references);
+            return Objects.requireNonNull(this.references.get());
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Add implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<Option> options;
+
+        List<Literal> sources;
+        Literal destination;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitAdd(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Add(Tree.randomId(), prefix, options, sources, destination, markers, eol);
+        }
+
+        // todo: builder function?
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Arg implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<DockerRightPadded<KeyArgs>> args;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitArg(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Arg(Tree.randomId(), prefix, args, markers, eol);
+        }
+
+        public static Arg build(String key, String value) {
+            return new Arg(Tree.randomId(), Space.EMPTY, List.of(
+                    DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
+            ), Markers.EMPTY, Space.NEWLINE);
+        }
+
+        public static Arg build(KeyArgs... args) {
+            return new Arg(Tree.randomId(), Space.EMPTY, Arrays.stream(args)
+                    .map(DockerRightPadded::build)
+                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Cmd implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Form form;
+        Space prefix;
+        Space execFormPrefix;
+        List<Literal> commands;
+        Space execFormSuffix;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitCmd(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Cmd(Tree.randomId(), form, prefix, execFormPrefix, commands, execFormSuffix, markers, eol);
+        }
+
+        public static Cmd build(String... commands) {
+            return build(Form.EXEC, commands);
+        }
+
+        public static Cmd build(Form form, String... commands) {
+            return new Cmd(Tree.randomId(), form, Space.EMPTY,
+                    Space.build(" "),
+                    Arrays.stream(commands)
+                            .map(s -> Literal.build(s)
+                                    .withQuoting(form == Form.EXEC ? Quoting.DOUBLE_QUOTED : Quoting.UNQUOTED)
+                                    .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
+                                    .withTrailing(Space.EMPTY)
+                            )
+                            .collect(Collectors.toList()),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Comment implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        Literal text;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitComment(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Comment(Tree.randomId(), prefix, text, markers, eol);
+        }
+
+        public static Comment build(String text) {
+            return new Comment(Tree.randomId(),
+                    Space.EMPTY,
+                    Literal.build(text).withPrefix(Space.build(" ")),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @With
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    class Copy implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<Option> options;
+        List<Literal> sources;
+        Literal destination;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitCopy(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Copy(Tree.randomId(), prefix, new ArrayList<>(options), sources, destination, markers, eol);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Directive implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Space prefix;
+        DockerRightPadded<KeyArgs> directive;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitDirective(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Directive(Tree.randomId(), prefix, directive, markers, eol);
+        }
+
+        public String getKey() {
+            return directive.getElement().key();
+        }
+
+        public Directive withKey(String key) {
+            if (same(directive.getElement().key(), key)) {
+                return this;
+            }
+
+            return this.withDirective(directive.map(d -> d.key(key)));
+        }
+
+        public Directive withValue(String value) {
+            if (same(directive.getElement().value(), value)) {
+                return this;
+            }
+
+            return this.withDirective(directive.map(d -> d.value(value)));
+        }
+
+        public String getValue() {
+            return directive.getElement().value();
+        }
+
+        public String getFullDirective() {
+            if (directive.getElement().getKey() == null) {
+                return "";
+            }
+
+            return directive.getElement().getKey() + "=" + directive.getElement().getValue();
+        }
+
+        public static Directive build(String key, String value) {
+            return new Directive(Tree.randomId(),
+                    Space.EMPTY,
+                    DockerRightPadded.build(
+                            new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED)
+                    ),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Entrypoint implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Form form;
+        Space prefix;
+        Space execFormPrefix;
+        List<Literal> commands;
+        Space execFormSuffix;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitEntrypoint(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Entrypoint(Tree.randomId(), form, prefix, execFormPrefix, commands, execFormSuffix, markers, eol);
+        }
+
+        public static Entrypoint build(String... commands) {
+            return build(Form.EXEC, commands);
+        }
+
+        public static Entrypoint build(Form form, String... commands) {
+            return new Entrypoint(Tree.randomId(),
+                    form,
+                    Space.EMPTY,
+                    form == Form.EXEC ? Space.build(" ") : Space.EMPTY,
+                    Arrays.stream(commands)
+                            .map(s -> Literal.build(s)
+                                    .withQuoting(form == Form.EXEC ? Quoting.DOUBLE_QUOTED : Quoting.UNQUOTED)
+                                    .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
+                                    .withTrailing(Space.EMPTY)
+                            )
+                            .collect(Collectors.toList()),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Env implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<DockerRightPadded<KeyArgs>> args;
+
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitEnv(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Env(Tree.randomId(), prefix, args, markers, eol);
+        }
+
+        public static Env build(String key, String value) {
+            return new Env(Tree.randomId(),
+                    Space.EMPTY,
+                    List.of(
+                            DockerRightPadded.build(
+                                    new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED)
+                            )
+                    ),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+
+        public static Env build(KeyArgs... args) {
+            return new Env(Tree.randomId(), Space.EMPTY, Arrays.stream(args)
+                    .map(arg -> {
+                        if ("".equals(arg.getPrefix().getWhitespace())) {
+                            return arg.withPrefix(Space.build(" "));
+                        }
+                        return arg;
+                    })
+                    .map(DockerRightPadded::build)
+                    .collect(Collectors.toCollection(ArrayList::new)),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Expose implements Instruction {
+
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<DockerRightPadded<Port>> ports;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitExpose(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Expose(Tree.randomId(), prefix, ports, markers, eol);
+        }
+
+        public static Expose build(String... ports) {
+            List<DockerRightPadded<Port>> portsList = new ArrayList<>();
+
+            for (String port : ports) {
+                String normalizedPort = null;
+                String protocol = null;
+                if (port != null && port.contains("/")) {
+                    String[] parts = port.split("/");
+                    protocol = parts[1];
+                    normalizedPort = parts[0];
+                } else {
+                    normalizedPort = port;
+                }
+
+                portsList.add(DockerRightPadded.build(
+                        new Port(Space.build(" "),
+                                normalizedPort,
+                                protocol == null ? "tcp" : protocol,
+                                protocol != null)));
+            }
+
+            return new Expose(Tree.randomId(),
+                    Space.EMPTY,
+                    portsList,
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class From implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Literal platform;
+        Literal image;
+        Literal version;
+        Literal as;
+        Literal alias;
+        Space trailing;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitFrom(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new From(Tree.randomId(), prefix, platform, image, version, as, alias, trailing, markers, eol);
+        }
+
+        public String getImageSpec() {
+            return image.getText();
+        }
+
+        public String getImageSpecWithVersion() {
+            if (version.getText() == null) {
+                return image.getText();
+            }
+            return image.getText() + version.getText();
+        }
+
+        public String getDigest() {
+            String v = version.getText();
+            if (v == null) {
+                return null;
+            }
+            return v.startsWith("@") ? v.substring(1) : null;
+        }
+
+        public From platform(String platform) {
+            return this.withPlatform(this.platform.withText(platform));
+        }
+
+        public From image(String image) {
+            return this.withImage(this.image.withText(image));
+        }
+
+        public From version(String version) {
+            return this.withVersion(this.version.withText(version));
+        }
+
+        public From withDigest(String digest) {
+            if (digest == null) {
+                return version(null);
+            }
+            digest = digest.indexOf('@') == 0 ? digest : "@" + digest;
+            return version(digest);
+        }
+
+        public From withTag(String tag) {
+            if (tag == null) {
+                return version(null);
+            }
+            tag = tag.indexOf(':') == 0 ? tag : ":" + tag;
+            return version(tag);
+        }
+
+        public String getTag() {
+            String v = version.getText();
+            if (v == null) {
+                return null;
+            }
+
+            return v.startsWith(":") ? v.substring(1) : null;
+        }
+
+        public From alias(String alias) {
+            From result = this;
+            if (this.as.getText() == null || this.as.getText().isBlank()) {
+                result = result.withAs(Literal.build("AS").withPrefix(this.as.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
+            }
+            return result.withAlias(this.alias.withText(alias).withPrefix(this.alias.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
+        }
+
+        public static From build(String image) {
+            return new From(Tree.randomId(),
+                    Space.EMPTY,
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    /*version*/Literal.build(null).withPrefix(Space.EMPTY).withTrailing(Space.EMPTY),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE).image(image);
+        }
+
+        public static From build(String prefix, String platform, String image, String version, String alias) {
+            return new From(Tree.randomId(), Space.build(prefix),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    alias != null && !alias.isBlank() ? Literal.build("AS").withPrefix(Space.build(" ")) : null,
+                    Literal.build(alias).withPrefix(Space.build(" ")),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE
+            )
+                    .image(image)
+                    .version(version)
+                    .platform(platform);
+        }
+    }
+
+    @Value
+    @With
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    class Healthcheck implements Instruction {
+        public enum Type {
+            CMD, NONE
+        }
+
+        @EqualsAndHashCode.Include
+        UUID id;
+        Space prefix;
+        Type type;
+
+        List<DockerRightPadded<KeyArgs>> options;
+        List<Literal> commands;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitHealthcheck(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Healthcheck(Tree.randomId(),
+                    prefix,
+                    type,
+                    options,
+                    commands,
+                    markers,
+                    eol);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Label implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<DockerRightPadded<KeyArgs>> args;
+
+        Markers markers;
+
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitLabel(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Label(Tree.randomId(), prefix, args, markers, eol);
+        }
+
+        public static Label build(String key, String value) {
+            return new Label(Tree.randomId(), Space.EMPTY, List.of(
+                    DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
+            ), Markers.EMPTY, Space.NEWLINE);
+        }
+
+        public static Label build(KeyArgs... args) {
+            return new Label(Tree.randomId(), Space.EMPTY, Arrays.stream(args)
+                    .map(DockerRightPadded::build)
+                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Maintainer implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Quoting quoting;
+        Space prefix;
+        Literal name;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitMaintainer(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Maintainer(Tree.randomId(), quoting, prefix, name, markers, eol);
+        }
+
+        public static Maintainer build(String name) {
+            if (name == null) {
+                return null;
+            }
+
+            Quoting quoting = Quoting.UNQUOTED;
+            if (name.startsWith("'") && name.endsWith("'")) {
+                name = trimSingleQuotes(name);
+                quoting = Quoting.SINGLE_QUOTED;
+            } else if (name.startsWith("\"") && name.endsWith("\"")) {
+                name = trimDoubleQuotes(name);
+                quoting = Quoting.DOUBLE_QUOTED;
+            }
+
+            return new Maintainer(Tree.randomId(), quoting, Space.EMPTY,
+                    Literal.build(name).withPrefix(Space.build(" ")),
+                    Markers.EMPTY, Space.NEWLINE);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class OnBuild implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Docker instruction;
+        Space trailing;
+
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitOnBuild(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new OnBuild(Tree.randomId(), prefix, instruction.copyPaste(), trailing, markers, eol);
+        }
+
+        public static OnBuild build(Docker instruction) {
+            return new OnBuild(Tree.randomId(), Space.EMPTY, instruction, Space.EMPTY, Markers.EMPTY, Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @With
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    class Run implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        List<Option> options;
+        List<Literal> commands;
+
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitRun(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Run(Tree.randomId(), prefix, options, commands, markers, eol);
+        }
+
+        public static Run build(String... commands) {
+            return new Run(Tree.randomId(),
+                    Space.EMPTY,
+                    null,
+                    Arrays.stream(commands)
+                            .map(s -> Literal.build(s).withPrefix(Space.build(" ")))
+                            .collect(Collectors.toList()),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Shell implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+
+        Space execFormPrefix;
+        List<Literal> commands;
+        Space execFormSuffix;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitShell(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Shell(Tree.randomId(), prefix, execFormPrefix, commands, execFormSuffix, markers, eol);
+        }
+
+        public static Shell build(String... commands) {
+            return new Shell(Tree.randomId(),
+                    Space.EMPTY,
+                    Space.build(" "),
+                    Arrays.stream(commands)
+                            .map(Literal::build)
+                            .collect(Collectors.toList()),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class StopSignal implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Space prefix;
+        Literal signal;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitStopSignal(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new StopSignal(Tree.randomId(), prefix, signal, markers, eol);
+        }
+
+        public static StopSignal build(String signal) {
+            return new StopSignal(Tree.randomId(),
+                    Space.EMPTY,
+                    Literal.build(signal).withPrefix(Space.build(" ")),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class User implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Literal username;
+        Literal group;
+
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitUser(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new User(Tree.randomId(), prefix, username, group, markers, eol);
+        }
+
+        public static User build(String username) {
+            return build(username, null);
+        }
+
+        public static User build(String username, String group) {
+            return new User(Tree.randomId(), Space.EMPTY,
+                    username == null ? null : Literal.build(username).withPrefix(Space.build(" ")),
+                    group == null ? null : Literal.build(group).withPrefix(Space.build(" ")),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Volume implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Form form;
+
+        Space prefix;
+
+        Space execFormPrefix;
+        List<Literal> paths;
+        Space execFormSuffix;
+
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitVolume(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Volume(Tree.randomId(), form, prefix, execFormPrefix, paths, execFormSuffix, markers, eol);
+        }
+
+
+        public static Volume build(String... commands) {
+            return build(Form.EXEC, commands);
+        }
+
+        public static Volume build(Form form, String... commands) {
+            return new Volume(Tree.randomId(),
+                    form,
+                    Space.EMPTY,
+                    form == Form.EXEC ? Space.build(" ") : Space.EMPTY,
+                    Arrays.stream(commands)
+                            .map(s -> Literal.build(s)
+                                    .withQuoting(form == Form.EXEC ? Quoting.DOUBLE_QUOTED : Quoting.UNQUOTED)
+                                    .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
+                                    .withTrailing(Space.EMPTY)
+                            )
+                            .collect(Collectors.toList()),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Stage implements Docker {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        List<Docker> children;
+
+        Markers markers;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitStage(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Stage copyPaste() {
+            return new Stage(Tree.randomId(), children, markers);
+        }
+
+        public static Stage build(Instruction... instructions) {
+            return new Stage(Tree.randomId(),
+                    Arrays.stream(instructions).collect(Collectors.toCollection(ArrayList::new)),
+                    Markers.EMPTY);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Workdir implements Instruction {
+        @EqualsAndHashCode.Include
+        UUID id;
+        Space prefix;
+        Literal path;
+        Markers markers;
+        Space eol;
+
+        @Override
+        public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
+            return v.visitWorkdir(this, p);
+        }
+
+        @Override
+        public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+            return new DockerfilePrinter<>();
+        }
+
+        @Override
+        public Docker copyPaste() {
+            return new Workdir(Tree.randomId(), prefix, path, markers, eol);
+        }
+
+        public static Workdir build(String path) {
+            return new Workdir(Tree.randomId(),
+                    Space.EMPTY,
+                    Literal.build(path).withPrefix(Space.build(" ")),
+                    Markers.EMPTY,
+                    Space.NEWLINE);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    @With
+    class KeyArgs {
+        Space prefix;
+        @EqualsAndHashCode.Include(rank = 1000)
+        Literal key;
+        @EqualsAndHashCode.Include(rank = 1000)
+        Literal value;
+        boolean hasEquals;
+        Quoting quoting;
+
+        public String key() {
+            return key.getText();
+        }
+
+        public String value() {
+            return value.getText();
+        }
+
+        public KeyArgs key(String key) {
+            return this.withKey(Literal.build(key));
+        }
+
+        public KeyArgs value(String value) {
+            return this.withValue(Literal.build(value));
+        }
+
+        public static KeyArgs build(String key, String value) {
+            return build(key, value, true);
+        }
+
+        public static KeyArgs build(String key, String value, boolean hasEquals) {
+            if (value != null && value.startsWith("\"") && value.endsWith("\"")) {
+                return new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(trimDoubleQuotes(value)), hasEquals, Quoting.DOUBLE_QUOTED);
+            } else if (value != null && value.startsWith("'")) {
+                return new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(trimSingleQuotes(value)), hasEquals, Quoting.SINGLE_QUOTED);
+            }
+
+            return new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), hasEquals, Quoting.UNQUOTED);
+        }
+    }
+
+    @Value
+    @With
+    @EqualsAndHashCode
+    class Port {
+        Space prefix;
+        String port;
+        String protocol;
+        boolean protocolProvided;
+    }
+}

--- a/src/main/java/org/openrewrite/docker/tree/DockerRightPadded.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerRightPadded.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.With;
+import lombok.experimental.FieldDefaults;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+@Data
+public class DockerRightPadded<T> {
+    @EqualsAndHashCode.Include(rank = 1000)
+    @With
+    T element;
+
+    @With
+    Space after;
+
+    @With
+    Markers markers;
+
+    public DockerRightPadded<T> map(UnaryOperator<T> map) {
+        return withElement(map.apply(element));
+    }
+
+    public static <T> List<T> getElements(List<DockerRightPadded<T>> ls) {
+        List<T> list = new ArrayList<>();
+        for (DockerRightPadded<T> l : ls) {
+            T elem = l.getElement();
+            list.add(elem);
+        }
+        return list;
+    }
+
+    public static <P extends Docker> List<DockerRightPadded<P>> withElements(List<DockerRightPadded<P>> before, List<P> elements) {
+        // a cheaper check for the most common case when there are no changes
+        if (elements.size() == before.size()) {
+            boolean hasChanges = false;
+            for (int i = 0; i < before.size(); i++) {
+                if (before.get(i).getElement() != elements.get(i)) {
+                    hasChanges = true;
+                    break;
+                }
+            }
+            if (!hasChanges) {
+                return before;
+            }
+        }
+
+        List<DockerRightPadded<P>> after = new ArrayList<>(elements.size());
+        Map<UUID, DockerRightPadded<P>> beforeById = before.stream().collect(Collectors
+                .toMap(j -> j.getElement().getId(), Function.identity()));
+
+        for (P t : elements) {
+            if (beforeById.get(t.getId()) != null) {
+                DockerRightPadded<P> found = beforeById.get(t.getId());
+                after.add(found.withElement(t));
+            } else {
+                after.add(new DockerRightPadded<>(t, Space.EMPTY, Markers.EMPTY));
+            }
+        }
+
+        return after;
+    }
+
+    public static <T> DockerRightPadded<T> build(T element) {
+        return new DockerRightPadded<>(element, Space.EMPTY, Markers.EMPTY);
+    }
+
+    @Nullable
+    public static <T> DockerRightPadded<T> withElement(@Nullable DockerRightPadded<T> before, @Nullable T elements) {
+        if (before == null) {
+            if (elements == null) {
+                return null;
+            }
+            return new DockerRightPadded<>(elements, Space.EMPTY, Markers.EMPTY);
+        }
+        if (elements == null) {
+            return null;
+        }
+        return before.withElement(elements);
+    }
+
+    @Override
+    public String toString() {
+        return "DockerfileRightPadded(element=" + element.getClass().getSimpleName() + ", after=" + after + ')';
+    }
+}

--- a/src/main/java/org/openrewrite/docker/tree/DockerRightPadded.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerRightPadded.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
@@ -14,11 +14,11 @@
  */
 package org.openrewrite.docker.tree;
 
-import org.openrewrite.docker.DockerVisitor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.docker.DockerVisitor;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;

--- a/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
@@ -108,10 +108,10 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     private void instructionName(Docker.Instruction instruction, PrintOutputCapture<P> p) {
         String defaultName = instruction.getClass().getSimpleName();
         p.append(
-            instruction.getMarkers().findFirst(InstructionName.class)
-                    .filter(f -> f.getName().equalsIgnoreCase(defaultName))
-                    .map(InstructionName::getName)
-                    .orElseGet(defaultName::toUpperCase)
+                instruction.getMarkers().findFirst(InstructionName.class)
+                        .filter(f -> f.getName().equalsIgnoreCase(defaultName))
+                        .map(InstructionName::getName)
+                        .orElseGet(defaultName::toUpperCase)
         );
     }
 

--- a/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/org/openrewrite/docker/tree/DockerfilePrinter.java
@@ -1,0 +1,669 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import org.openrewrite.docker.DockerVisitor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import static org.openrewrite.docker.internal.StringUtil.trimDoubleQuotes;
+
+public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
+    private static final UnaryOperator<String> MARKER_WRAPPER =
+            out -> "/*~~" + out + (out.isEmpty() ? "" : "~~") + ">*/";
+
+    protected void beforeSyntax(Docker t, PrintOutputCapture<P> p) {
+        beforeSyntax(t.getPrefix(), t.getMarkers(), p);
+    }
+
+    @Override
+    public @NonNull Markers visitMarkers(@Nullable Markers markers, PrintOutputCapture<P> p) {
+        if (markers == null) {
+            return Markers.EMPTY;
+        }
+        return super.visitMarkers(markers, p);
+    }
+
+    protected void beforeSyntax(Space prefix, Markers markers, PrintOutputCapture<P> p) {
+        visitSpace(prefix, p);
+
+        if (markers == null || markers.getMarkers().isEmpty()) {
+            return;
+        }
+
+        for (Marker marker : markers.getMarkers()) {
+            p.append(p.getMarkerPrinter().beforePrefix(marker, new Cursor(getCursor(), marker), MARKER_WRAPPER));
+        }
+        visitSpace(prefix, p);
+        visitMarkers(markers, p);
+        for (Marker marker : markers.getMarkers()) {
+            p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), MARKER_WRAPPER));
+        }
+    }
+
+    protected void afterSyntax(Docker t, PrintOutputCapture<P> p) {
+        if (t instanceof Docker.Instruction) {
+            Docker.Instruction instruction = (Docker.Instruction) t;
+            if (instruction.getEol() != null) {
+                visitSpace(instruction.getEol(), p);
+            }
+        }
+        afterSyntax(t.getMarkers(), p);
+    }
+
+    protected void afterSyntax(Markers markers, PrintOutputCapture<P> p) {
+        if (markers == null) {
+            return;
+        }
+        for (Marker marker : markers.getMarkers()) {
+            p.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), MARKER_WRAPPER));
+        }
+    }
+
+    @Override
+    public Docker visitDocument(Docker.Document dockerfile, PrintOutputCapture<P> p) {
+        List<Docker.Stage> stages = dockerfile.getStages();
+        for (int i = 0; i < stages.size(); i++) {
+            Docker.Stage stage = stages.get(i);
+            visit(stage, p);
+        }
+
+        visitSpace(dockerfile.getEof(), p);
+
+        return dockerfile;
+    }
+
+    @Override
+    public Docker visitStage(Docker.Stage stage, PrintOutputCapture<P> p) {
+        beforeSyntax(stage, p);
+        List<Docker> children = stage.getChildren();
+        for (int i = 0; i < children.size(); i++) {
+            Docker instruction = children.get(i);
+            visit(instruction, p);
+        }
+        afterSyntax(stage, p);
+        return stage;
+    }
+
+    private void instructionName(Docker.Instruction instruction, PrintOutputCapture<P> p) {
+        String defaultName = instruction.getClass().getSimpleName();
+        p.append(
+            instruction.getMarkers().findFirst(InstructionName.class)
+                    .filter(f -> f.getName().equalsIgnoreCase(defaultName))
+                    .map(InstructionName::getName)
+                    .orElseGet(defaultName::toUpperCase)
+        );
+    }
+
+    @Override
+    public Docker visitFrom(Docker.From from, PrintOutputCapture<P> p) {
+        beforeSyntax(from, p);
+        instructionName(from, p);
+        if (from.getPlatform() != null && !StringUtils.isBlank(from.getPlatform().getText())) {
+            visitSpace(from.getPlatform().getPrefix(), p);
+            if (!from.getPlatform().getText().startsWith("--")) {
+                if ("".equals(from.getPlatform().getPrefix().getWhitespace())) {
+                    p.append(" ");
+                }
+                p.append("--platform=");
+            }
+
+            p.append(from.getPlatform().getText());
+            visitSpace(from.getPlatform().getTrailing(), p);
+        }
+
+        visitLiteral(from.getImage(), p);
+        visitLiteral(from.getVersion(), p);
+
+        if (from.getAlias() != null &&
+            from.getAlias().getText() != null) {
+            visitLiteral(from.getAs(), p);
+            visitLiteral(from.getAlias(), p);
+        }
+
+        afterSyntax(from, p);
+        return from;
+    }
+
+    @Override
+    public Space visitSpace(Space space, PrintOutputCapture<P> p) {
+        if (space == null) {
+            return Space.EMPTY;
+        }
+        if (space.getWhitespace() != null) {
+            p.append(space.getWhitespace());
+        }
+        return space;
+    }
+
+    @Override
+    public Docker visitComment(Docker.Comment comment, PrintOutputCapture<P> p) {
+        Docker.Literal literal = comment.getText();
+        if (literal != null) {
+            beforeSyntax(comment, p);
+            p.append("#");
+            visitLiteral(literal.withText(literal.getText().replaceAll("\n", "\n# ")), p);
+            afterSyntax(comment, p);
+        }
+        return comment;
+    }
+
+    @Override
+    public Docker visitDirective(Docker.Directive directive, PrintOutputCapture<P> p) {
+        beforeSyntax(directive, p);
+        p.append("#");
+        DockerRightPadded<Docker.KeyArgs> padded = directive.getDirective();
+        Docker.KeyArgs keyArgs = padded.getElement();
+        visitKeyArgs(keyArgs, p);
+        visitSpace(padded.getAfter(), p);
+        afterSyntax(directive, p);
+        return directive;
+    }
+
+    @Override
+    public Docker visitRun(Docker.Run run, PrintOutputCapture<P> p) {
+        beforeSyntax(run, p);
+        instructionName(run, p);
+        if (run.getOptions() != null) {
+            run.getOptions().forEach(o -> {
+                visitOption(o, p);
+            });
+        }
+
+        if (run.getCommands() != null) {
+            for (int i = 0; i < run.getCommands().size(); i++) {
+                visitLiteral(run.getCommands().get(i), p);
+            }
+        }
+
+        afterSyntax(run, p);
+        return run;
+    }
+
+    @Override
+    public Docker visitCmd(Docker.Cmd cmd, PrintOutputCapture<P> p) {
+        beforeSyntax(cmd, p);
+        instructionName(cmd, p);
+        Form form = cmd.getForm();
+        if (form == null) {
+            form = Form.EXEC;
+        }
+        if (form == Form.EXEC) {
+            p.append(" [");
+        }
+
+        for (int i = 0; i < cmd.getCommands().size(); i++) {
+            Docker.Literal literal = cmd.getCommands().get(i);
+            String text = literal.getText();
+            visitSpace(literal.getPrefix(), p);
+
+            if (form == Form.EXEC) {
+                text = trimDoubleQuotes(text);
+                p.append("\"").append(text).append("\"");
+                if (i < cmd.getCommands().size() - 1) {
+                    p.append(",");
+                }
+            } else {
+                p.append(text);
+            }
+            visitSpace(literal.getTrailing(), p);
+        }
+
+        if (form == Form.EXEC) {
+            p.append("]");
+        }
+        afterSyntax(cmd, p);
+        return cmd;
+    }
+
+    private Docker.Literal visitFormLiteral(Form form, Docker.Literal literal, PrintOutputCapture<P> p) {
+        if (literal == null) {
+            return null;
+        }
+        visitSpace(literal.getPrefix(), p);
+        if (literal.getText() != null) {
+            p.append(literal.getText());
+        }
+        visitSpace(literal.getTrailing(), p);
+        return literal;
+    }
+
+    @Override
+    public Docker visitLiteral(Docker.Literal literal, PrintOutputCapture<P> p) {
+        visitSpace(literal.getPrefix(), p);
+        visitQuoting(literal.getQuoting(), p);
+        if (literal.getText() != null) {
+            p.append(literal.getText());
+        }
+        visitQuoting(literal.getQuoting(), p);
+        visitSpace(literal.getTrailing(), p);
+        afterSyntax(literal, p);
+        return literal;
+    }
+
+    @Override
+    public Docker visitOption(Docker.Option option, PrintOutputCapture<P> p) {
+        if (option == null) {
+            return null;
+        }
+
+        visitSpace(option.getPrefix(), p);
+        visitKeyArgs(option.getKeyArgs(), p);
+        afterSyntax(option, p);
+        return option;
+    }
+
+    private DockerRightPadded<Docker.Literal> visitDockerRightPaddedLiteral(DockerRightPadded<Docker.Literal> padded, PrintOutputCapture<P> p) {
+        if (padded == null) {
+            return null;
+        }
+
+        visitLiteral(padded.getElement(), p);
+        visitSpace(padded.getAfter(), p);
+        afterSyntax(padded.getMarkers(), p);
+
+        return padded;
+    }
+
+    private Docker.KeyArgs visitKeyArgs(Docker.KeyArgs keyArgs, PrintOutputCapture<P> p) {
+        if (keyArgs == null) {
+            return null;
+        }
+        visitSpace(keyArgs.getPrefix(), p);
+        if (keyArgs.key() != null && !keyArgs.key().isEmpty()) {
+            visitLiteral(keyArgs.getKey(), p);
+        }
+        if (keyArgs.isHasEquals()) {
+            p.append("=");
+        }
+        if (keyArgs.getQuoting() == Quoting.SINGLE_QUOTED) {
+            p.append("'").append(keyArgs.value()).append("'");
+        } else if (keyArgs.getQuoting() == Quoting.DOUBLE_QUOTED) {
+            p.append("\"").append(keyArgs.value()).append("\"");
+        } else {
+            visitLiteral(keyArgs.getValue(), p);
+        }
+        return keyArgs;
+    }
+
+    @Override
+    public Docker visitLabel(Docker.Label label, PrintOutputCapture<P> p) {
+        beforeSyntax(label, p);
+        instructionName(label, p);
+        for (DockerRightPadded<Docker.KeyArgs> padded : label.getArgs()) {
+            visitKeyArgs(padded.getElement(), p);
+            visitSpace(padded.getAfter(), p);
+        }
+        afterSyntax(label, p);
+        return label;
+    }
+
+    @Override
+    public Docker visitMaintainer(Docker.Maintainer maintainer, PrintOutputCapture<P> p) {
+        beforeSyntax(maintainer, p);
+        instructionName(maintainer, p);
+        visitLiteral(maintainer.getName(), p);
+        afterSyntax(maintainer, p);
+        return maintainer;
+    }
+
+    @Override
+    public Docker visitExpose(Docker.Expose expose, PrintOutputCapture<P> p) {
+        beforeSyntax(expose, p);
+        instructionName(expose, p);
+        for (int i = 0; i < expose.getPorts().size(); i++) {
+            DockerRightPadded<Docker.Port> padded = expose.getPorts().get(i);
+            Docker.Port port = padded.getElement();
+            visitSpace(port.getPrefix(), p);
+            p.append(port.getPort());
+            if (port.isProtocolProvided() && port.getProtocol() != null && !port.getProtocol().isEmpty()) {
+                p.append("/");
+                p.append(port.getProtocol());
+            }
+            visitSpace(padded.getAfter(), p);
+        }
+        afterSyntax(expose, p);
+        return expose;
+    }
+
+    private void visitQuoting(Quoting quoting, PrintOutputCapture<P> p) {
+        if (quoting == Quoting.SINGLE_QUOTED) {
+            p.append("'");
+        } else if (quoting == Quoting.DOUBLE_QUOTED) {
+            p.append("\"");
+        }
+    }
+
+    @Override
+    public Docker visitEnv(Docker.Env env, PrintOutputCapture<P> p) {
+        beforeSyntax(env, p);
+        instructionName(env, p);
+
+        for (DockerRightPadded<Docker.KeyArgs> padded : env.getArgs()) {
+            Docker.KeyArgs kvp = padded.getElement();
+            visitSpace(kvp.getPrefix(), p);
+            p.append(kvp.key());
+            if (kvp.value() != null && !kvp.value().isEmpty()) {
+                if (kvp.isHasEquals()) {
+                    p.append("=");
+                } else {
+                    p.append(" ");
+                }
+
+                visitQuoting(kvp.getQuoting(), p);
+                p.append(kvp.value());
+                visitQuoting(kvp.getQuoting(), p);
+            }
+
+            visitSpace(padded.getAfter(), p);
+        }
+        afterSyntax(env, p);
+        return env;
+    }
+
+    @Override
+    public Docker visitAdd(Docker.Add add, PrintOutputCapture<P> p) {
+        beforeSyntax(add, p);
+        instructionName(add, p);
+
+        if (add.getOptions() != null) {
+            add.getOptions().forEach(o -> {
+                visitOption(o, p);
+            });
+        }
+
+        if (add.getSources() != null) {
+            for (int i = 0; i < add.getSources().size(); i++) {
+                visitLiteral(add.getSources().get(i), p);
+            }
+        }
+
+        visitLiteral(add.getDestination(), p);
+
+        afterSyntax(add, p);
+        return add;
+    }
+
+    @Override
+    public Docker visitCopy(Docker.Copy copy, PrintOutputCapture<P> p) {
+        beforeSyntax(copy, p);
+        instructionName(copy, p);
+
+        if (copy.getOptions() != null) {
+            copy.getOptions().forEach(o -> {
+                visitOption(o, p);
+            });
+        }
+
+        if (copy.getSources() != null) {
+            for (int i = 0; i < copy.getSources().size(); i++) {
+                visitLiteral(copy.getSources().get(i), p);
+            }
+        }
+
+        visitLiteral(copy.getDestination(), p);
+
+        afterSyntax(copy, p);
+        return copy;
+    }
+
+    @Override
+    public Docker visitEntrypoint(Docker.Entrypoint entrypoint, PrintOutputCapture<P> p) {
+        beforeSyntax(entrypoint, p);
+        instructionName(entrypoint, p);
+
+        if (entrypoint.getForm() == Form.EXEC) {
+            Space before = entrypoint.getExecFormPrefix();
+            if (before == null || before.isEmpty()) {
+                before = Space.build(" ");
+            }
+            visitSpace(before, p);
+
+            p.append("[");
+        }
+
+        List<Docker.Literal> commands = entrypoint.getCommands();
+        for (int i = 0; i < commands.size(); i++) {
+            Docker.Literal literal = commands.get(i);
+
+            if (entrypoint.getForm() == Form.SHELL
+                && i > 0
+                && i < commands.size() - 1
+                && "".equals(literal.getPrefix().getWhitespace())) {
+                p.append(" ");
+            }
+
+            visitLiteral(literal, p);
+
+            if (i < commands.size() - 1 && entrypoint.getForm() == Form.EXEC) {
+                p.append(",");
+            }
+        }
+        if (entrypoint.getForm() == Form.EXEC) {
+            p.append("]");
+            visitSpace(entrypoint.getExecFormSuffix(), p);
+        }
+        afterSyntax(entrypoint, p);
+        return entrypoint;
+    }
+
+    @Override
+    public Docker visitVolume(Docker.Volume volume, PrintOutputCapture<P> p) {
+        beforeSyntax(volume, p);
+        instructionName(volume, p);
+
+        if (volume.getForm() == Form.EXEC) {
+            Space before = volume.getExecFormPrefix();
+            if (before == null || before.isEmpty()) {
+                before = Space.build(" ");
+            }
+            visitSpace(before, p);
+            p.append("[");
+        }
+
+        for (int i = 0; i < volume.getPaths().size(); i++) {
+            Docker.Literal literal = volume.getPaths().get(i);
+            if (volume.getForm() == Form.SHELL
+                && i > 0
+                && i < volume.getPaths().size() - 1
+                && "".equals(literal.getPrefix().getWhitespace())) {
+                p.append(" ");
+            }
+
+            visitLiteral(literal, p);
+
+            if (volume.getForm() == Form.EXEC && i < volume.getPaths().size() - 1) {
+                p.append(",");
+            }
+        }
+
+        if (volume.getForm() == Form.EXEC) {
+            p.append("]");
+            visitSpace(volume.getExecFormSuffix(), p);
+        }
+
+        afterSyntax(volume, p);
+        return volume;
+    }
+
+    @Override
+    public Docker visitUser(Docker.User user, PrintOutputCapture<P> p) {
+        beforeSyntax(user, p);
+        instructionName(user, p);
+        visitSpace(user.getUsername().getPrefix(), p);
+        p.append(user.getUsername().getText());
+        visitSpace(user.getUsername().getTrailing(), p);
+        if (user.getGroup() != null && user.getGroup().getText() != null && !user.getGroup().getText().isEmpty()) {
+            p.append(":");
+            visitSpace(user.getGroup().getPrefix(), p);
+            p.append(user.getGroup().getText());
+            visitSpace(user.getGroup().getTrailing(), p);
+        }
+        afterSyntax(user, p);
+        return user;
+    }
+
+    @Override
+    public Docker visitWorkdir(Docker.Workdir workdir, PrintOutputCapture<P> p) {
+        beforeSyntax(workdir, p);
+        instructionName(workdir, p);
+        visitLiteral(workdir.getPath(), p);
+        afterSyntax(workdir, p);
+        return workdir;
+    }
+
+    @Override
+    public Docker visitArg(Docker.Arg arg, PrintOutputCapture<P> p) {
+        beforeSyntax(arg, p);
+        instructionName(arg, p);
+        arg.getArgs().forEach(padded -> {
+            Docker.KeyArgs args = padded.getElement();
+            if (args.getValue().getText() != null) {
+                visitKeyArgs(args, p);
+            } else {
+                // ARG without a value is a special case where we don't want to output KEY=
+                visitSpace(args.getPrefix(), p);
+                visitLiteral(args.getKey(), p);
+            }
+            visitSpace(padded.getAfter(), p);
+        });
+        afterSyntax(arg, p);
+        return arg;
+    }
+
+    @Override
+    public Docker visitOnBuild(Docker.OnBuild onBuild, PrintOutputCapture<P> p) {
+        beforeSyntax(onBuild, p);
+        instructionName(onBuild, p);
+        p.append(" ");
+        visit(onBuild.getInstruction(), p);
+        afterSyntax(onBuild, p);
+        return onBuild;
+    }
+
+    @Override
+    public Docker visitStopSignal(Docker.StopSignal stopSignal, PrintOutputCapture<P> p) {
+        beforeSyntax(stopSignal, p);
+        instructionName(stopSignal, p);
+        visitSpace(stopSignal.getPrefix(), p);
+        visitLiteral(stopSignal.getSignal(), p);
+        afterSyntax(stopSignal, p);
+        return stopSignal;
+    }
+
+    @Override
+    public Docker visitHealthcheck(Docker.Healthcheck healthcheck, PrintOutputCapture<P> p) {
+        beforeSyntax(healthcheck, p);
+        instructionName(healthcheck, p);
+
+        if (healthcheck.getType() == Docker.Healthcheck.Type.NONE) {
+            p.append(" NONE");
+            afterSyntax(healthcheck, p);
+            return healthcheck;
+        }
+
+        if (healthcheck.getOptions() != null) {
+            healthcheck.getOptions().forEach(o -> {
+                Docker.KeyArgs arg = o.getElement();
+                if (!arg.key().startsWith("--")) {
+                    arg = new Docker.KeyArgs(arg.getPrefix(), Docker.Literal.prepend("--", arg.getKey()), arg.getValue(), arg.isHasEquals(), arg.getQuoting());
+                }
+                visitKeyArgs(arg, p);
+                visitSpace(o.getAfter(), p);
+            });
+        }
+
+        if (healthcheck.getCommands() != null) {
+            for (int i = 0; i < healthcheck.getCommands().size(); i++) {
+                Docker.Literal command = healthcheck.getCommands().get(i);
+
+                if (i == 0 && "CMD".equals(command.getText())) {
+                    if (command.getPrefix().isEmpty()) {
+                        p.append(" ");
+                    }
+                    p.append("CMD");
+                    visitSpace(command.getPrefix(), p);
+                    continue;
+                } else if (i == 0) {
+                    p.append(" CMD");
+                }
+
+                if (i > 0 && "".equals(command.getPrefix().getWhitespace())) {
+                    p.append(" ");
+                }
+
+                visitLiteral(command, p);
+            }
+        }
+
+        afterSyntax(healthcheck, p);
+        return healthcheck;
+    }
+
+    @Override
+    public Docker visitShell(Docker.Shell shell, PrintOutputCapture<P> p) {
+        beforeSyntax(shell, p);
+        instructionName(shell, p);
+        if ("".equals(shell.getExecFormPrefix().getWhitespace())) {
+            p.append(" ");
+        } else {
+            p.append(shell.getExecFormPrefix().getWhitespace());
+        }
+        p.append("[");
+
+        for (int i = 0; i < shell.getCommands().size(); i++) {
+            Docker.Literal literal = shell.getCommands().get(i);
+            if (literal.getQuoting() != Quoting.DOUBLE_QUOTED) {
+                literal = ((Docker.Literal) literal.copyPaste())
+                        .withQuoting(Quoting.DOUBLE_QUOTED)
+                        .withText(trimDoubleQuotes(literal.getText()));
+            }
+
+            visitLiteral(literal, p);
+
+            if (i < shell.getCommands().size() - 1) {
+                p.append(",");
+            }
+        }
+
+        p.append("]");
+
+        visitSpace(shell.getExecFormSuffix(), p);
+        afterSyntax(shell, p);
+        return shell;
+    }
+
+    private void appendRightPaddedLiteral(DockerRightPadded<Docker.Literal> padded, PrintOutputCapture<P> p) {
+        if (padded == null) {
+            return;
+        }
+
+        Docker.Literal literal = padded.getElement();
+        if (literal == null || literal.getText() == null || literal.getText().isEmpty()) {
+            return;
+        }
+        visitSpace(literal.getPrefix(), p);
+        p.append(literal.getText());
+        visitSpace(padded.getAfter(), p);
+    }
+}

--- a/src/main/java/org/openrewrite/docker/tree/Form.java
+++ b/src/main/java/org/openrewrite/docker/tree/Form.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/Form.java
+++ b/src/main/java/org/openrewrite/docker/tree/Form.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+public enum Form {
+    SHELL,
+    EXEC
+}

--- a/src/main/java/org/openrewrite/docker/tree/InstructionName.java
+++ b/src/main/java/org/openrewrite/docker/tree/InstructionName.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+@Value
+@With
+public class InstructionName implements Marker {
+    UUID id;
+    String name;
+}

--- a/src/main/java/org/openrewrite/docker/tree/InstructionName.java
+++ b/src/main/java/org/openrewrite/docker/tree/InstructionName.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/Quoting.java
+++ b/src/main/java/org/openrewrite/docker/tree/Quoting.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+/**
+ * Represents a quoting style.
+ */
+public enum Quoting {
+    /**
+     * Represents an unquoted value.
+     */
+    UNQUOTED,
+    /**
+     * Represents a single-quoted value.
+     */
+    SINGLE_QUOTED,
+    /**
+     * Represents a double-quoted value.
+     */
+    DOUBLE_QUOTED
+}

--- a/src/main/java/org/openrewrite/docker/tree/Quoting.java
+++ b/src/main/java/org/openrewrite/docker/tree/Quoting.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/openrewrite/docker/tree/Space.java
+++ b/src/main/java/org/openrewrite/docker/tree/Space.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import lombok.EqualsAndHashCode;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.UnaryOperator;
+
+/**
+ * Dockerfile white space.
+ */
+@EqualsAndHashCode
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
+public class Space {
+    public static final Space EMPTY = new Space("");
+    public static final Space NEWLINE = new Space("\n");
+
+    @Nullable
+    private final String whitespace;
+
+    /*
+     * Most occurrences of spaces will have no comments or markers and will be repeated frequently throughout a source file.
+     * e.g.: a single space between keywords, or the common indentation of every line in a block.
+     * So use flyweights to avoid storing many instances of functionally identical spaces
+     */
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
+
+    private Space(@Nullable String whitespace) {
+        this.whitespace = whitespace == null || whitespace.isEmpty() ? null : whitespace;
+    }
+
+    public Space map(UnaryOperator<String> mapper) {
+        String mapped = mapper.apply(whitespace);
+        if (mapped == null || mapped.isEmpty()) {
+            return EMPTY;
+        }
+        if (mapped.equals(whitespace)) {
+            return this;
+        }
+        return build(mapped);
+    }
+
+    @JsonCreator
+    public static Space build(@Nullable String whitespace) {
+        if (whitespace == null || whitespace.isEmpty()) {
+            return Space.EMPTY;
+        } else if (whitespace.length() <= 100) {
+            //noinspection StringOperationCanBeSimplified
+            return flyweights.computeIfAbsent(whitespace, k -> new Space(new String(whitespace)));
+        }
+        return new Space(whitespace);
+    }
+
+    public static Space append(Space prefix, Space suffix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return suffix;
+        }
+        if (suffix == null || suffix.isEmpty()) {
+            return prefix;
+        }
+        return build(prefix.getWhitespace() + suffix.getWhitespace());
+    }
+
+    public String getIndent() {
+        return getWhitespaceIndent(whitespace);
+    }
+
+    private String getWhitespaceIndent(@Nullable String whitespace) {
+        if (whitespace == null) {
+            return "";
+        }
+        int lastNewline = whitespace.lastIndexOf('\n');
+        if (lastNewline >= 0) {
+            return whitespace.substring(lastNewline + 1);
+        } else if (lastNewline == whitespace.length() - 1) {
+            return "";
+        }
+        return whitespace;
+    }
+
+    public String getWhitespace() {
+        return whitespace == null ? "" : whitespace;
+    }
+
+
+    public Space withWhitespace(String whitespace) {
+        if (whitespace.isEmpty()) {
+            return Space.EMPTY;
+        }
+
+        if (this.whitespace == null || whitespace.equals(this.whitespace)) {
+            return this;
+        }
+        return build(whitespace);
+    }
+
+    public boolean isEmpty() {
+        return this == EMPTY;
+    }
+
+    public static Space format(String formatting) {
+        return Space.build(formatting);
+    }
+
+    private static final String[] spaces = {
+            "·₁", "·₂", "·₃", "·₄", "·₅", "·₆", "·₇", "·₈", "·₉", "·₊"
+    };
+
+    private static final String[] tabs = {
+            "-₁", "-₂", "-₃", "-₄", "-₅", "-₆", "-₇", "-₈", "-₉", "-₊"
+    };
+
+    @Override
+    public String toString() {
+        StringBuilder printedWs = new StringBuilder();
+        int lastNewline = 0;
+        if (whitespace != null) {
+            char[] charArray = whitespace.toCharArray();
+            for (int i = 0; i < charArray.length; i++) {
+                char c = charArray[i];
+                if (c == '\n') {
+                    printedWs.append("\\n");
+                    lastNewline = i + 1;
+                } else if (c == '\r') {
+                    printedWs.append("\\r");
+                    lastNewline = i + 1;
+                } else if (c == ' ') {
+                    printedWs.append(spaces[(i - lastNewline) % 10]);
+                } else if (c == '\t') {
+                    printedWs.append(tabs[(i - lastNewline) % 10]);
+                }
+            }
+        }
+
+        return "Space(whitespace='" + printedWs + "')";
+    }
+}

--- a/src/main/java/org/openrewrite/docker/tree/Space.java
+++ b/src/main/java/org/openrewrite/docker/tree/Space.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
+++ b/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class AddOrUpdateDirectiveTest  implements RewriteTest {
+    @Test
+    void addDirective() {
+        rewriteRun(
+            spec -> spec.expectedCyclesThatMakeChanges(1)
+                    .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                    .recipe(new AddOrUpdateDirective("check=error=true")),
+            dockerfile(
+                """
+                FROM myImage:latest
+                """
+                ,
+                """
+                # check=error=true
+                FROM myImage:latest
+                """
+            )
+        );
+    }
+
+    @Test
+    void addDirectiveWhenMultiple() {
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("syntax=docker/dockerfile:1")),
+                dockerfile(
+                        """
+                        # check=error=true
+                        # escape=`
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # syntax=docker/dockerfile:1
+                        # check=error=true
+                        # escape=`
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void updateDirective() {
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("check=error=true")),
+                dockerfile(
+                        """
+                        # check=error=false
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void updateDirectiveComplex() {
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("check=skip=JSONArgsRecommended;error=true")),
+                dockerfile(
+                        """
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # check=skip=JSONArgsRecommended;error=true
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void updateDirectiveWhenMultiple() {
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("escape=|")),
+                dockerfile(
+                        """
+                        # syntax=docker/dockerfile:1
+                        # escape=`
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # syntax=docker/dockerfile:1
+                        # escape=|
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void updateDirectiveWhenCasingMismatch() {
+        // According to docker's docs, all of these are the same. But the parser currently doesn't return the preceding spaces or spaces around the equals sign.
+        // #directive=value
+        // # directive =value
+        // #	directive= value
+        // # directive = value
+        // #	  dIrEcTiVe=value
+        // see https://docs.docker.com/reference/dockerfile/#syntax
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("escape=|")),
+                dockerfile(
+                        """
+                        # syntax=docker/dockerfile:1
+                        # eScApE=`
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # syntax=docker/dockerfile:1
+                        # escape=|
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void addDirectiveWhenMixedWitHComments() {
+        rewriteRun(
+                spec -> spec.expectedCyclesThatMakeChanges(1)
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .recipe(new AddOrUpdateDirective("escape=|")),
+                dockerfile(
+                        """
+                        # syntax=docker/dockerfile:1
+                        # unknowndirective=value
+                        # escape=`
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                        ,
+                        """
+                        # syntax=docker/dockerfile:1
+                        # unknowndirective=value
+                        # escape=|
+                        # check=error=true
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
+++ b/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
@@ -20,110 +20,110 @@ import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.docker.Assertions.dockerfile;
 
-class AddOrUpdateDirectiveTest  implements RewriteTest {
+class AddOrUpdateDirectiveTest implements RewriteTest {
     @Test
     void addDirective() {
         rewriteRun(
-            spec -> spec.expectedCyclesThatMakeChanges(1)
-                    .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                    .recipe(new AddOrUpdateDirective("check=error=true")),
-            dockerfile(
-                """
-                FROM myImage:latest
-                """
-                ,
-                """
-                # check=error=true
-                FROM myImage:latest
-                """
-            )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("check=error=true")),
+          dockerfile(
+            """
+            FROM myImage:latest
+            """
+            ,
+            """
+            # check=error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void addDirectiveWhenMultiple() {
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("syntax=docker/dockerfile:1")),
-                dockerfile(
-                        """
-                        # check=error=true
-                        # escape=`
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # syntax=docker/dockerfile:1
-                        # check=error=true
-                        # escape=`
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("syntax=docker/dockerfile:1")),
+          dockerfile(
+            """
+            # check=error=true
+            # escape=`
+            FROM myImage:latest
+            """
+            ,
+            """
+            # syntax=docker/dockerfile:1
+            # check=error=true
+            # escape=`
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void updateDirective() {
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("check=error=true")),
-                dockerfile(
-                        """
-                        # check=error=false
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("check=error=true")),
+          dockerfile(
+            """
+            # check=error=false
+            FROM myImage:latest
+            """
+            ,
+            """
+            # check=error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void updateDirectiveComplex() {
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("check=skip=JSONArgsRecommended;error=true")),
-                dockerfile(
-                        """
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # check=skip=JSONArgsRecommended;error=true
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("check=skip=JSONArgsRecommended;error=true")),
+          dockerfile(
+            """
+            # check=error=true
+            FROM myImage:latest
+            """
+            ,
+            """
+            # check=skip=JSONArgsRecommended;error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void updateDirectiveWhenMultiple() {
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("escape=|")),
-                dockerfile(
-                        """
-                        # syntax=docker/dockerfile:1
-                        # escape=`
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # syntax=docker/dockerfile:1
-                        # escape=|
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("escape=|")),
+          dockerfile(
+            """
+            # syntax=docker/dockerfile:1
+            # escape=`
+            # check=error=true
+            FROM myImage:latest
+            """
+            ,
+            """
+            # syntax=docker/dockerfile:1
+            # escape=|
+            # check=error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 
@@ -137,50 +137,50 @@ class AddOrUpdateDirectiveTest  implements RewriteTest {
         // #	  dIrEcTiVe=value
         // see https://docs.docker.com/reference/dockerfile/#syntax
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("escape=|")),
-                dockerfile(
-                        """
-                        # syntax=docker/dockerfile:1
-                        # eScApE=`
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # syntax=docker/dockerfile:1
-                        # escape=|
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("escape=|")),
+          dockerfile(
+            """
+            # syntax=docker/dockerfile:1
+            # eScApE=`
+            # check=error=true
+            FROM myImage:latest
+            """
+            ,
+            """
+            # syntax=docker/dockerfile:1
+            # escape=|
+            # check=error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void addDirectiveWhenMixedWitHComments() {
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(1)
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .recipe(new AddOrUpdateDirective("escape=|")),
-                dockerfile(
-                        """
-                        # syntax=docker/dockerfile:1
-                        # unknowndirective=value
-                        # escape=`
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                        ,
-                        """
-                        # syntax=docker/dockerfile:1
-                        # unknowndirective=value
-                        # escape=|
-                        # check=error=true
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new AddOrUpdateDirective("escape=|")),
+          dockerfile(
+            """
+            # syntax=docker/dockerfile:1
+            # unknowndirective=value
+            # escape=`
+            # check=error=true
+            FROM myImage:latest
+            """
+            ,
+            """
+            # syntax=docker/dockerfile:1
+            # unknowndirective=value
+            # escape=|
+            # check=error=true
+            FROM myImage:latest
+            """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
+++ b/src/test/java/org/openrewrite/docker/AddOrUpdateDirectiveTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
+++ b/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
@@ -27,21 +27,21 @@ import static org.openrewrite.test.SourceSpecs.text;
 class AsDockerfileTest implements RewriteTest {
     /**
      * Assert that the recipe run results in a single Dockerfile with a single FROM statement:
-     *    FROM alpine:latest
+     * FROM alpine:latest
      *
      * @param after The recipe run status
      */
     private static void assertSimpleFrom(RecipeRun after) {
         assertThat(after.getChangeset().getAllResults()).hasSize(1);
         assertThat(Objects.requireNonNull(after.getChangeset().getAllResults().get(0).getAfter()))
-                .isInstanceOf(Docker.Document.class);
+          .isInstanceOf(Docker.Document.class);
 
         Docker.Document doc = (Docker.Document) after.getChangeset().getAllResults().get(0).getAfter();
         assertThat(doc).isNotNull();
         assertThat(doc.getStages()).hasSize(1);
         assertThat(doc.getStages().get(0)).isNotNull();
 
-        Docker.From from =(Docker.From)doc.getStages().get(0).getChildren().get(0);
+        Docker.From from = (Docker.From) doc.getStages().get(0).getChildren().get(0);
         assertThat(from.getImage().getText()).isEqualTo("alpine");
         assertThat(from.getVersion().getText()).isEqualTo(":latest");
     }
@@ -50,16 +50,16 @@ class AsDockerfileTest implements RewriteTest {
     void loadPlainTextAsDockerDocument() {
         rewriteRun(
           spec -> spec.recipe(new AsDockerfile("**/*.build"))
-                  .afterRecipe(AsDockerfileTest::assertSimpleFrom),
-                text(
-                        """
-                        FROM alpine:latest
-                        """,
-                        """
-                        FROM alpine:latest
-                        """,
-                        spec -> spec.path("build/Dockerfile.build")
-                )
+            .afterRecipe(AsDockerfileTest::assertSimpleFrom),
+          text(
+            """
+            FROM alpine:latest
+            """,
+            """
+            FROM alpine:latest
+            """,
+            spec -> spec.path("build/Dockerfile.build")
+          )
         );
     }
 
@@ -67,46 +67,46 @@ class AsDockerfileTest implements RewriteTest {
     void loadPlainTextAllowsMultiplePatterns() {
         rewriteRun(
           spec -> spec.recipe(new AsDockerfile("**/*.build;**/*.docker"))
-                  .afterRecipe(AsDockerfileTest::assertSimpleFrom),
-                text(
-                        """
-                        FROM alpine:latest
-                        """,
-                        """
-                        FROM alpine:latest
-                        """,
-                        spec -> spec.path("build/build.docker")
-                )
+            .afterRecipe(AsDockerfileTest::assertSimpleFrom),
+          text(
+            """
+            FROM alpine:latest
+            """,
+            """
+            FROM alpine:latest
+            """,
+            spec -> spec.path("build/build.docker")
+          )
         );
     }
 
     @Test
     void loadPlainTextWithinDeclarativeRecipe() {
         rewriteRun(
-                  spec -> spec.recipeFromYaml(
-                          //language=yaml
-                          """
-                          type: specs.openrewrite.org/v1beta/recipe
-                          name: org.openrewrite.docker.AsDockerfileTest
-                          displayName: AsDockerfileTest
-                          description: Load plain text as Docker document.
-                          recipeList:
-                            - org.openrewrite.docker.AsDockerfile:
-                                pattern: "**/*.build"
-                            - org.openrewrite.docker.ModifyLiteral:
-                                matchText: "alpine"
-                                replacementText: "myimage"
-                          """,
-                          "org.openrewrite.docker.AsDockerfileTest"),
-                text(
-                        """
-                        FROM alpine:latest
-                        """,
-                        """
-                        FROM myimage:latest
-                        """,
-                        spec -> spec.path("build/build.docker")
-                )
+          spec -> spec.recipeFromYaml(
+            //language=yaml
+            """
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.docker.AsDockerfileTest
+            displayName: AsDockerfileTest
+            description: Load plain text as Docker document.
+            recipeList:
+              - org.openrewrite.docker.AsDockerfile:
+                  pattern: "**/*.build"
+              - org.openrewrite.docker.ModifyLiteral:
+                  matchText: "alpine"
+                  replacementText: "myimage"
+            """,
+            "org.openrewrite.docker.AsDockerfileTest"),
+          text(
+            """
+            FROM alpine:latest
+            """,
+            """
+            FROM myimage:latest
+            """,
+            spec -> spec.path("build/build.docker")
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
+++ b/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
+++ b/src/test/java/org/openrewrite/docker/AsDockerfileTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.openrewrite.docker.tree.Docker;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.test.SourceSpecs.text;
+
+class AsDockerfileTest implements RewriteTest {
+    /**
+     * Assert that the recipe run results in a single Dockerfile with a single FROM statement:
+     *    FROM alpine:latest
+     *
+     * @param after The recipe run status
+     */
+    private static void assertSimpleFrom(RecipeRun after) {
+        assertThat(after.getChangeset().getAllResults()).hasSize(1);
+        assertThat(Objects.requireNonNull(after.getChangeset().getAllResults().get(0).getAfter()))
+                .isInstanceOf(Docker.Document.class);
+
+        Docker.Document doc = (Docker.Document) after.getChangeset().getAllResults().get(0).getAfter();
+        assertThat(doc).isNotNull();
+        assertThat(doc.getStages()).hasSize(1);
+        assertThat(doc.getStages().get(0)).isNotNull();
+
+        Docker.From from =(Docker.From)doc.getStages().get(0).getChildren().get(0);
+        assertThat(from.getImage().getText()).isEqualTo("alpine");
+        assertThat(from.getVersion().getText()).isEqualTo(":latest");
+    }
+
+    @Test
+    void loadPlainTextAsDockerDocument() {
+        rewriteRun(
+          spec -> spec.recipe(new AsDockerfile("**/*.build"))
+                  .afterRecipe(AsDockerfileTest::assertSimpleFrom),
+                text(
+                        """
+                        FROM alpine:latest
+                        """,
+                        """
+                        FROM alpine:latest
+                        """,
+                        spec -> spec.path("build/Dockerfile.build")
+                )
+        );
+    }
+
+    @Test
+    void loadPlainTextAllowsMultiplePatterns() {
+        rewriteRun(
+          spec -> spec.recipe(new AsDockerfile("**/*.build;**/*.docker"))
+                  .afterRecipe(AsDockerfileTest::assertSimpleFrom),
+                text(
+                        """
+                        FROM alpine:latest
+                        """,
+                        """
+                        FROM alpine:latest
+                        """,
+                        spec -> spec.path("build/build.docker")
+                )
+        );
+    }
+
+    @Test
+    void loadPlainTextWithinDeclarativeRecipe() {
+        rewriteRun(
+                  spec -> spec.recipeFromYaml(
+                          //language=yaml
+                          """
+                          type: specs.openrewrite.org/v1beta/recipe
+                          name: org.openrewrite.docker.AsDockerfileTest
+                          displayName: AsDockerfileTest
+                          description: Load plain text as Docker document.
+                          recipeList:
+                            - org.openrewrite.docker.AsDockerfile:
+                                pattern: "**/*.build"
+                            - org.openrewrite.docker.ModifyLiteral:
+                                matchText: "alpine"
+                                replacementText: "myimage"
+                          """,
+                          "org.openrewrite.docker.AsDockerfileTest"),
+                text(
+                        """
+                        FROM alpine:latest
+                        """,
+                        """
+                        FROM myimage:latest
+                        """,
+                        spec -> spec.path("build/build.docker")
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/Assertions.java
+++ b/src/test/java/org/openrewrite/docker/Assertions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+
+import org.openrewrite.docker.tree.Docker;
+import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.SourceSpecs;
+
+import java.util.function.Consumer;
+
+public class Assertions {
+    private Assertions() {
+    }
+
+    public static SourceSpecs dockerfile(@Language("dockerfile") @Nullable String before) {
+        return Assertions.dockerfile(before, s -> {
+        });
+    }
+
+    public static SourceSpecs dockerfile(@Language("dockerfile") @Nullable String before, Consumer<SourceSpec<Docker.Document>> spec) {
+        SourceSpec<Docker.Document> doc = new SourceSpec<>(Docker.Document.class, null, DockerParser.builder(), before, null);
+        doc.path("Dockerfile");
+        spec.accept(doc);
+        return doc;
+    }
+
+    public static SourceSpecs dockerfile(@Language("dockerfile") @Nullable String before, @Language("dockerfile") @Nullable String after) {
+        return dockerfile(before, after, s -> {
+        });
+    }
+
+    public static SourceSpecs dockerfile(@Language("dockerfile") @Nullable String before, @Language("dockerfile") @Nullable String after,
+                                         Consumer<SourceSpec<Docker.Document>> spec) {
+        SourceSpec<Docker.Document> doc = new SourceSpec<>(Docker.Document.class, null, DockerParser.builder(), before, s -> after);
+        doc.path("Dockerfile");
+        spec.accept(doc);
+        return doc;
+    }
+}

--- a/src/test/java/org/openrewrite/docker/Assertions.java
+++ b/src/test/java/org/openrewrite/docker/Assertions.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/ChangeImageTest.java
+++ b/src/test/java/org/openrewrite/docker/ChangeImageTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class ChangeImageTest implements RewriteTest {
+    @Test
+    void noChange() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM doNotTouch
+                    """
+                )
+        );
+    }
+
+    @Test
+    void changeImageName() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM oldImage
+                    """,
+                    """
+                    FROM newImage
+                    """
+                )
+        );
+    }
+
+    @Test
+    void changeImageNameWithOtherElements() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM --platform=linux/amd64 oldImage AS base
+                    FROM --platform=linux/amd64 doNotTouch
+                    """,
+                    """
+                    FROM --platform=linux/amd64 newImage AS base
+                    FROM --platform=linux/amd64 doNotTouch
+                    """
+                )
+        );
+    }
+
+
+    @Test
+    void changeImageNameWithOtherElementsLowercaseAs() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM --platform=linux/amd64 oldImage as base
+                    FROM --platform=linux/amd64 doNotTouch
+                    """,
+                    """
+                    FROM --platform=linux/amd64 newImage as base
+                    FROM --platform=linux/amd64 doNotTouch
+                    """
+                )
+        );
+    }
+
+
+    @Test
+    void keepVersionWhenSuppliedNull() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM oldImage:latest
+                    """,
+                    """
+                    FROM newImage:latest
+                    """
+                )
+        );
+    }
+
+    @Test
+    void removeVersionWhenSuppliedEmptyString() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", "", null)),
+                dockerfile(
+                    """
+                    FROM oldImage:latest
+                    """
+                    ,
+                    """
+                    FROM newImage
+                    """
+                )
+        );
+    }
+
+    @Test
+    void removePlatformWhenSuppliedEmptyString() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, "")),
+                dockerfile(
+                    """
+                    FROM --platform=linux/amd64 oldImage:latest
+                    """,
+                    """
+                    FROM newImage:latest
+                    """
+                )
+        );
+    }
+
+    @Test
+    void testChangeImageWithNonStandardWhitespace() {
+        rewriteRun(
+                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+                dockerfile(
+                    """
+                    FROM    --platform=linux/amd64    oldImage:latest as   base
+                    """,
+                    """
+                    FROM    --platform=linux/amd64    newImage:latest as   base
+                    """
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/ChangeImageTest.java
+++ b/src/test/java/org/openrewrite/docker/ChangeImageTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/ChangeImageTest.java
+++ b/src/test/java/org/openrewrite/docker/ChangeImageTest.java
@@ -23,44 +23,44 @@ class ChangeImageTest implements RewriteTest {
     @Test
     void noChange() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM doNotTouch
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM doNotTouch
+            """
+          )
         );
     }
 
     @Test
     void changeImageName() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM oldImage
-                    """,
-                    """
-                    FROM newImage
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM oldImage
+            """,
+            """
+            FROM newImage
+            """
+          )
         );
     }
 
     @Test
     void changeImageNameWithOtherElements() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM --platform=linux/amd64 oldImage AS base
-                    FROM --platform=linux/amd64 doNotTouch
-                    """,
-                    """
-                    FROM --platform=linux/amd64 newImage AS base
-                    FROM --platform=linux/amd64 doNotTouch
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM --platform=linux/amd64 oldImage AS base
+            FROM --platform=linux/amd64 doNotTouch
+            """,
+            """
+            FROM --platform=linux/amd64 newImage AS base
+            FROM --platform=linux/amd64 doNotTouch
+            """
+          )
         );
     }
 
@@ -68,17 +68,17 @@ class ChangeImageTest implements RewriteTest {
     @Test
     void changeImageNameWithOtherElementsLowercaseAs() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM --platform=linux/amd64 oldImage as base
-                    FROM --platform=linux/amd64 doNotTouch
-                    """,
-                    """
-                    FROM --platform=linux/amd64 newImage as base
-                    FROM --platform=linux/amd64 doNotTouch
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM --platform=linux/amd64 oldImage as base
+            FROM --platform=linux/amd64 doNotTouch
+            """,
+            """
+            FROM --platform=linux/amd64 newImage as base
+            FROM --platform=linux/amd64 doNotTouch
+            """
+          )
         );
     }
 
@@ -86,61 +86,61 @@ class ChangeImageTest implements RewriteTest {
     @Test
     void keepVersionWhenSuppliedNull() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM oldImage:latest
-                    """,
-                    """
-                    FROM newImage:latest
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM oldImage:latest
+            """,
+            """
+            FROM newImage:latest
+            """
+          )
         );
     }
 
     @Test
     void removeVersionWhenSuppliedEmptyString() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", "", null)),
-                dockerfile(
-                    """
-                    FROM oldImage:latest
-                    """
-                    ,
-                    """
-                    FROM newImage
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", "", null)),
+          dockerfile(
+            """
+            FROM oldImage:latest
+            """
+            ,
+            """
+            FROM newImage
+            """
+          )
         );
     }
 
     @Test
     void removePlatformWhenSuppliedEmptyString() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, "")),
-                dockerfile(
-                    """
-                    FROM --platform=linux/amd64 oldImage:latest
-                    """,
-                    """
-                    FROM newImage:latest
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("oldImage:.*", "newImage", null, "")),
+          dockerfile(
+            """
+            FROM --platform=linux/amd64 oldImage:latest
+            """,
+            """
+            FROM newImage:latest
+            """
+          )
         );
     }
 
     @Test
     void testChangeImageWithNonStandardWhitespace() {
         rewriteRun(
-                spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
-                dockerfile(
-                    """
-                    FROM    --platform=linux/amd64    oldImage:latest as   base
-                    """,
-                    """
-                    FROM    --platform=linux/amd64    newImage:latest as   base
-                    """
-                )
+          spec -> spec.recipe(new ChangeImage("old.*", "newImage", null, null)),
+          dockerfile(
+            """
+            FROM    --platform=linux/amd64    oldImage:latest as   base
+            """,
+            """
+            FROM    --platform=linux/amd64    newImage:latest as   base
+            """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
+++ b/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+import static org.openrewrite.test.SourceSpecs.text;
+
+class EnsureDockerignoreTest implements RewriteTest {
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.recipe(new EnsureDockerignore());
+    }
+
+    @Test
+    void dockerfileExistsDockerignoreDoesNot() throws IOException {
+        rewriteRun(
+                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test")),
+                text(
+                        //language=dockerignore
+                        null,
+                        """
+                        *.md
+                        *.test
+                        """,
+                        spec -> spec.path(Paths.get(".dockerignore"))
+                )
+        );
+    }
+
+    @Test
+    void dockerignoreAlreadyIncludesSomePatterns() throws IOException {
+        rewriteRun(
+                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
+                        .expectedCyclesThatMakeChanges(1),
+                dockerfile(
+                        //language=dockerfile
+                        """
+                        FROM alpine:latest
+                        """,
+                        spec -> spec.path(Paths.get("Dockerfile"))
+                ),
+                text(
+                        //language=dockerignore
+                        """
+                        # This is a comment
+                        *.test
+                        *.DS_Store
+                        *.swp
+                        """,
+                        //language=dockerignore
+                        """
+                        # This is a comment
+                        *.test
+                        *.DS_Store
+                        *.swp
+                        *.bak
+                        *.log
+                        *.md
+                        *.tmp
+                        """,
+                        spec -> spec.path(Paths.get(".dockerignore"))
+                )
+        );
+    }
+
+    @Test
+    void dockerignoreAlreadyIncludesAllPatterns() throws IOException {
+        rewriteRun(
+                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
+                        .expectedCyclesThatMakeChanges(0),
+                text(
+                        //language=dockerignore
+                        """
+                        # This is a comment
+                        *.test
+                        *.DS_Store
+                        *.swp
+                        *.bak
+                        *.log
+                        *.md
+                        *.tmp
+                        """,
+                        spec -> spec.path(Paths.get(".dockerignore"))
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
+++ b/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
@@ -32,74 +32,74 @@ class EnsureDockerignoreTest implements RewriteTest {
     @Test
     void dockerfileExistsDockerignoreDoesNot() throws IOException {
         rewriteRun(
-                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test")),
-                text(
-                        //language=dockerignore
-                        null,
-                        """
-                        *.md
-                        *.test
-                        """,
-                        spec -> spec.path(Paths.get(".dockerignore"))
-                )
+          spec -> spec.recipe(new EnsureDockerignore("*.md,*.test")),
+          text(
+            //language=dockerignore
+            null,
+            """
+            *.md
+            *.test
+            """,
+            spec -> spec.path(Paths.get(".dockerignore"))
+          )
         );
     }
 
     @Test
     void dockerignoreAlreadyIncludesSomePatterns() throws IOException {
         rewriteRun(
-                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
-                        .expectedCyclesThatMakeChanges(1),
-                dockerfile(
-                        //language=dockerfile
-                        """
-                        FROM alpine:latest
-                        """,
-                        spec -> spec.path(Paths.get("Dockerfile"))
-                ),
-                text(
-                        //language=dockerignore
-                        """
-                        # This is a comment
-                        *.test
-                        *.DS_Store
-                        *.swp
-                        """,
-                        //language=dockerignore
-                        """
-                        # This is a comment
-                        *.test
-                        *.DS_Store
-                        *.swp
-                        *.bak
-                        *.log
-                        *.md
-                        *.tmp
-                        """,
-                        spec -> spec.path(Paths.get(".dockerignore"))
-                )
+          spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
+            .expectedCyclesThatMakeChanges(1),
+          dockerfile(
+            //language=dockerfile
+            """
+            FROM alpine:latest
+            """,
+            spec -> spec.path(Paths.get("Dockerfile"))
+          ),
+          text(
+            //language=dockerignore
+            """
+            # This is a comment
+            *.test
+            *.DS_Store
+            *.swp
+            """,
+            //language=dockerignore
+            """
+            # This is a comment
+            *.test
+            *.DS_Store
+            *.swp
+            *.bak
+            *.log
+            *.md
+            *.tmp
+            """,
+            spec -> spec.path(Paths.get(".dockerignore"))
+          )
         );
     }
 
     @Test
     void dockerignoreAlreadyIncludesAllPatterns() throws IOException {
         rewriteRun(
-                spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
-                        .expectedCyclesThatMakeChanges(0),
-                text(
-                        //language=dockerignore
-                        """
-                        # This is a comment
-                        *.test
-                        *.DS_Store
-                        *.swp
-                        *.bak
-                        *.log
-                        *.md
-                        *.tmp
-                        """,
-                        spec -> spec.path(Paths.get(".dockerignore"))
-                )
+          spec -> spec.recipe(new EnsureDockerignore("*.md,*.test,*.log,*.tmp,*.bak,*.swp,*.DS_Store"))
+            .expectedCyclesThatMakeChanges(0),
+          text(
+            //language=dockerignore
+            """
+            # This is a comment
+            *.test
+            *.DS_Store
+            *.swp
+            *.bak
+            *.log
+            *.md
+            *.tmp
+            """,
+            spec -> spec.path(Paths.get(".dockerignore"))
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
+++ b/src/test/java/org/openrewrite/docker/EnsureDockerignoreTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
+++ b/src/test/java/org/openrewrite/docker/FindDockerImagesUsedTest.java
@@ -45,17 +45,17 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
-              LABEL maintainer="Hugging Face"
-              ARG DEBIAN_FRONTEND=noninteractive
-              SHELL ["sh", "-lc"]
-              """,
+            FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+            LABEL maintainer="Hugging Face"
+            ARG DEBIAN_FRONTEND=noninteractive
+            SHELL ["sh", "-lc"]
+            """,
             """
-              FROM ~~(nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04)~~>nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
-              LABEL maintainer="Hugging Face"
-              ARG DEBIAN_FRONTEND=noninteractive
-              SHELL ["sh", "-lc"]
-              """,
+            FROM ~~(nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04)~~>nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+            LABEL maintainer="Hugging Face"
+            ARG DEBIAN_FRONTEND=noninteractive
+            SHELL ["sh", "-lc"]
+            """,
             spec -> spec.path(path)
           )
         );
@@ -67,25 +67,25 @@ class FindDockerImagesUsedTest implements RewriteTest {
           assertImages("golang:1.7.0", "golang:1.7.0", "golang:1.7.3"),
           yaml(
             """
-              test:
-                image: golang:1.7.3
+            test:
+              image: golang:1.7.3
 
-              accp:
-                image: golang:1.7.0
+            accp:
+              image: golang:1.7.0
 
-              prod:
-                image: golang:1.7.0
-              """,
+            prod:
+              image: golang:1.7.0
+            """,
             """
-              test:
-                image: ~~(golang:1.7.3)~~>golang:1.7.3
+            test:
+              image: ~~(golang:1.7.3)~~>golang:1.7.3
 
-              accp:
-                image: ~~(golang:1.7.0)~~>golang:1.7.0
+            accp:
+              image: ~~(golang:1.7.0)~~>golang:1.7.0
 
-              prod:
-                image: ~~(golang:1.7.0)~~>golang:1.7.0
-              """
+            prod:
+              image: ~~(golang:1.7.0)~~>golang:1.7.0
+            """
           )
         );
     }
@@ -97,23 +97,23 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM golang:1.7.3 AS builder
-              # another FROM to prove aliases can be used
-              FROM builder AS stage1
-              WORKDIR /go/src/github.com/alexellis/href-counter/
-              RUN go get -d -v golang.org/x/net/html
-              COPY app.go .
-              RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
-              """,
+            FROM golang:1.7.3 AS builder
+            # another FROM to prove aliases can be used
+            FROM builder AS stage1
+            WORKDIR /go/src/github.com/alexellis/href-counter/
+            RUN go get -d -v golang.org/x/net/html
+            COPY app.go .
+            RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+            """,
             """
-              FROM ~~(golang:1.7.3)~~>golang:1.7.3 AS builder
-              # another FROM to prove aliases can be used
-              FROM builder AS stage1
-              WORKDIR /go/src/github.com/alexellis/href-counter/
-              RUN go get -d -v golang.org/x/net/html
-              COPY app.go .
-              RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
-              """,
+            FROM ~~(golang:1.7.3)~~>golang:1.7.3 AS builder
+            # another FROM to prove aliases can be used
+            FROM builder AS stage1
+            WORKDIR /go/src/github.com/alexellis/href-counter/
+            RUN go get -d -v golang.org/x/net/html
+            COPY app.go .
+            RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -126,31 +126,31 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM golang:1.7.3 as builder
-              WORKDIR /go/src/github.com/alexellis/href-counter/
-              RUN go get -d -v golang.org/x/net/html
-              COPY app.go .
-              RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+            FROM golang:1.7.3 as builder
+            WORKDIR /go/src/github.com/alexellis/href-counter/
+            RUN go get -d -v golang.org/x/net/html
+            COPY app.go .
+            RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-              from alpine:latest
-              run apk --no-cache add ca-certificates
-              workdir /root/
-              copy --from=builder /go/src/github.com/alexellis/href-counter/app .
-              cmd ["./app"]
-              """,
+            from alpine:latest
+            run apk --no-cache add ca-certificates
+            workdir /root/
+            copy --from=builder /go/src/github.com/alexellis/href-counter/app .
+            cmd ["./app"]
+            """,
             """
-              FROM ~~(golang:1.7.3)~~>golang:1.7.3 as builder
-              WORKDIR /go/src/github.com/alexellis/href-counter/
-              RUN go get -d -v golang.org/x/net/html
-              COPY app.go .
-              RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+            FROM ~~(golang:1.7.3)~~>golang:1.7.3 as builder
+            WORKDIR /go/src/github.com/alexellis/href-counter/
+            RUN go get -d -v golang.org/x/net/html
+            COPY app.go .
+            RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-              from ~~(alpine:latest)~~>alpine:latest
-              run apk --no-cache add ca-certificates
-              workdir /root/
-              copy --from=builder /go/src/github.com/alexellis/href-counter/app .
-              cmd ["./app"]
-              """,
+            from ~~(alpine:latest)~~>alpine:latest
+            run apk --no-cache add ca-certificates
+            workdir /root/
+            copy --from=builder /go/src/github.com/alexellis/href-counter/app .
+            cmd ["./app"]
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -163,21 +163,21 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM alpine:latest
-              COPY --from=nginx:latest /etc/nginx/nginx.conf /etc/nginx/
-              COPY --from=nginx:latest /usr/share/nginx/html /usr/share/nginx/html
-              RUN apk add --no-cache bash
-              WORKDIR /usr/share/nginx/html
-              CMD ["ls", "-la", "/usr/share/nginx/html"]
-              """,
+            FROM alpine:latest
+            COPY --from=nginx:latest /etc/nginx/nginx.conf /etc/nginx/
+            COPY --from=nginx:latest /usr/share/nginx/html /usr/share/nginx/html
+            RUN apk add --no-cache bash
+            WORKDIR /usr/share/nginx/html
+            CMD ["ls", "-la", "/usr/share/nginx/html"]
+            """,
             """
-              FROM ~~(alpine:latest)~~>alpine:latest
-              COPY --from=~~(nginx:latest)~~>nginx:latest /etc/nginx/nginx.conf /etc/nginx/
-              COPY --from=~~(nginx:latest)~~>nginx:latest /usr/share/nginx/html /usr/share/nginx/html
-              RUN apk add --no-cache bash
-              WORKDIR /usr/share/nginx/html
-              CMD ["ls", "-la", "/usr/share/nginx/html"]
-              """,
+            FROM ~~(alpine:latest)~~>alpine:latest
+            COPY --from=~~(nginx:latest)~~>nginx:latest /etc/nginx/nginx.conf /etc/nginx/
+            COPY --from=~~(nginx:latest)~~>nginx:latest /usr/share/nginx/html /usr/share/nginx/html
+            RUN apk add --no-cache bash
+            WORKDIR /usr/share/nginx/html
+            CMD ["ls", "-la", "/usr/share/nginx/html"]
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -190,45 +190,45 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              # syntax=docker/dockerfile:1
-              FROM golang:1.23
-              WORKDIR /src
-              COPY <<EOF ./main.go
-              package main
+            # syntax=docker/dockerfile:1
+            FROM golang:1.23
+            WORKDIR /src
+            COPY <<EOF ./main.go
+            package main
 
-              import "fmt"
+            import "fmt"
 
-              func main() {
-                fmt.Println("hello, world")
-              }
-              EOF
+            func main() {
+              fmt.Println("hello, world")
+            }
+            EOF
 
-              RUN go build -o /bin/hello ./main.go
+            RUN go build -o /bin/hello ./main.go
 
-              FROM scratch
-              COPY --from=0 /bin/hello /bin/hello
-              CMD ["/bin/hello"]
-              """,
+            FROM scratch
+            COPY --from=0 /bin/hello /bin/hello
+            CMD ["/bin/hello"]
+            """,
             """
-              # syntax=docker/dockerfile:1
-              FROM ~~(golang:1.23)~~>golang:1.23
-              WORKDIR /src
-              COPY <<EOF ./main.go
-              package main
+            # syntax=docker/dockerfile:1
+            FROM ~~(golang:1.23)~~>golang:1.23
+            WORKDIR /src
+            COPY <<EOF ./main.go
+            package main
 
-              import "fmt"
+            import "fmt"
 
-              func main() {
-                fmt.Println("hello, world")
-              }
-              EOF
+            func main() {
+              fmt.Println("hello, world")
+            }
+            EOF
 
-              RUN go build -o /bin/hello ./main.go
+            RUN go build -o /bin/hello ./main.go
 
-              FROM ~~(scratch)~~>scratch
-              COPY --from=0 /bin/hello /bin/hello
-              CMD ["/bin/hello"]
-              """,
+            FROM ~~(scratch)~~>scratch
+            COPY --from=0 /bin/hello /bin/hello
+            CMD ["/bin/hello"]
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -242,15 +242,15 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM --platform=linux/arm64 alpine:latest
-              RUN echo "Hello from ARM64!" > /message.txt
-              CMD ["cat", "/message.txt"]
-              """,
+            FROM --platform=linux/arm64 alpine:latest
+            RUN echo "Hello from ARM64!" > /message.txt
+            CMD ["cat", "/message.txt"]
+            """,
             """
-              FROM --platform=linux/arm64 ~~(alpine:latest)~~>alpine:latest
-              RUN echo "Hello from ARM64!" > /message.txt
-              CMD ["cat", "/message.txt"]
-              """,
+            FROM --platform=linux/arm64 ~~(alpine:latest)~~>alpine:latest
+            RUN echo "Hello from ARM64!" > /message.txt
+            CMD ["cat", "/message.txt"]
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -263,17 +263,17 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              # FROM alpine
-              FROM alpine:latest
-              # more comments
-              FROM eclipse-temurin:17-jammy
-              """,
+            # FROM alpine
+            FROM alpine:latest
+            # more comments
+            FROM eclipse-temurin:17-jammy
+            """,
             """
-              # FROM alpine
-              FROM ~~(alpine:latest)~~>alpine:latest
-              # more comments
-              FROM ~~(eclipse-temurin:17-jammy)~~>eclipse-temurin:17-jammy
-              """,
+            # FROM alpine
+            FROM ~~(alpine:latest)~~>alpine:latest
+            # more comments
+            FROM ~~(eclipse-temurin:17-jammy)~~>eclipse-temurin:17-jammy
+            """,
             spec -> spec.path("Dockerfile")
           )
         );
@@ -287,19 +287,19 @@ class FindDockerImagesUsedTest implements RewriteTest {
           text(
             //language=Dockerfile
             """
-              FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+            FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 
-              RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
-              RUN dpkg --add-architecture arm64
-              RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
-              """,
+            RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
+            RUN dpkg --add-architecture arm64
+            RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
+            """,
             """
-              FROM ~~(ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main)~~>ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+            FROM ~~(ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main)~~>ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 
-              RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
-              RUN dpkg --add-architecture arm64
-              RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
-              """,
+            RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
+            RUN dpkg --add-architecture arm64
+            RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64
+            """,
             spec -> spec.path(fileName)
           )
         );
@@ -312,63 +312,63 @@ class FindDockerImagesUsedTest implements RewriteTest {
           //language=yaml
           yaml(
             """
-              image: maven:latest
+            image: maven:latest
 
-              variables:
-                MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
-                MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository"
+            variables:
+              MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+              MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository"
 
-              cache:
-                paths:
-                  - .m2/repository/
-                  - target/
+            cache:
+              paths:
+                - .m2/repository/
+                - target/
 
-              build:
-                stage: build
-                script:
-                  - mvn $MAVEN_CLI_OPTS compile
+            build:
+              stage: build
+              script:
+                - mvn $MAVEN_CLI_OPTS compile
 
-              test:
-                stage: test
-                script:
-                  - mvn $MAVEN_CLI_OPTS test
+            test:
+              stage: test
+              script:
+                - mvn $MAVEN_CLI_OPTS test
 
-              deploy:
-                stage: deploy
-                script:
-                  - mvn $MAVEN_CLI_OPTS deploy
-                only:
-                  - master
-              """,
+            deploy:
+              stage: deploy
+              script:
+                - mvn $MAVEN_CLI_OPTS deploy
+              only:
+                - master
+            """,
             """
-              image: ~~(maven:latest)~~>maven:latest
+            image: ~~(maven:latest)~~>maven:latest
 
-              variables:
-                MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
-                MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository"
+            variables:
+              MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+              MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository"
 
-              cache:
-                paths:
-                  - .m2/repository/
-                  - target/
+            cache:
+              paths:
+                - .m2/repository/
+                - target/
 
-              build:
-                stage: build
-                script:
-                  - mvn $MAVEN_CLI_OPTS compile
+            build:
+              stage: build
+              script:
+                - mvn $MAVEN_CLI_OPTS compile
 
-              test:
-                stage: test
-                script:
-                  - mvn $MAVEN_CLI_OPTS test
+            test:
+              stage: test
+              script:
+                - mvn $MAVEN_CLI_OPTS test
 
-              deploy:
-                stage: deploy
-                script:
-                  - mvn $MAVEN_CLI_OPTS deploy
-                only:
-                  - master
-              """,
+            deploy:
+              stage: deploy
+              script:
+                - mvn $MAVEN_CLI_OPTS deploy
+              only:
+                - master
+            """,
             spec -> spec.path(".gitlab-ci")
           )
         );
@@ -381,13 +381,13 @@ class FindDockerImagesUsedTest implements RewriteTest {
           //language=yaml
           yaml(
             """
-              container:
-                image: ghcr.io/owner/image
-              """,
+            container:
+              image: ghcr.io/owner/image
+            """,
             """
-              container:
-                image: ~~(ghcr.io/owner/image)~~>ghcr.io/owner/image
-              """,
+            container:
+              image: ~~(ghcr.io/owner/image)~~>ghcr.io/owner/image
+            """,
             spec -> spec.path(".github/workflows/ci.yml")
           )
         );
@@ -400,55 +400,55 @@ class FindDockerImagesUsedTest implements RewriteTest {
           //language=yaml
           yaml(
             """
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - image: image
-                    name: image-container
-              ---
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - name: my-container
-                    image: app:v1.2.3
-                initContainers:
-                  - image: account/image:latest
-                    name: my-init-container
-              ---
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - image: repo.id/account/bucket/image:v1.2.3@digest
-                    name: my-container
-              """,
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - image: image
+                  name: image-container
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - name: my-container
+                  image: app:v1.2.3
+              initContainers:
+                - image: account/image:latest
+                  name: my-init-container
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - image: repo.id/account/bucket/image:v1.2.3@digest
+                  name: my-container
+            """,
             """
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - image: ~~(image)~~>image
-                    name: image-container
-              ---
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - name: my-container
-                    image: ~~(app:v1.2.3)~~>app:v1.2.3
-                initContainers:
-                  - image: ~~(account/image:latest)~~>account/image:latest
-                    name: my-init-container
-              ---
-              apiVersion: v1
-              kind: Pod
-              spec:
-                containers:
-                  - image: ~~(repo.id/account/bucket/image:v1.2.3@digest)~~>repo.id/account/bucket/image:v1.2.3@digest
-                    name: my-container
-              """,
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - image: ~~(image)~~>image
+                  name: image-container
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - name: my-container
+                  image: ~~(app:v1.2.3)~~>app:v1.2.3
+              initContainers:
+                - image: ~~(account/image:latest)~~>account/image:latest
+                  name: my-init-container
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+              containers:
+                - image: ~~(repo.id/account/bucket/image:v1.2.3@digest)~~>repo.id/account/bucket/image:v1.2.3@digest
+                  name: my-container
+            """,
             spec -> spec.path(".gitlab-ci")
           )
         );

--- a/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class ModifyLiteralTest implements RewriteTest {
+    @Test
+    void replacesAllMatchingLiterals() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyLiteral("(?:.*)(17)(?:(?=\\-jdk-slim|-openjdk).*)", "21")),
+
+                dockerfile(
+                        """
+                        # Use a specific base image with Java installed
+                        FROM openjdk:17-jdk-slim
+
+                        # Set environment variables for Java paths
+                        ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+                        ENV PATH=$JAVA_HOME/bin:$PATH
+
+                        # Example RUN commands using hard-coded Java paths
+                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
+                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
+
+                        # Set the working directory
+                        WORKDIR /app
+
+                        # Copy application files into the container
+                        COPY . .
+
+                        # Compile the application
+                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
+
+                        # Command to run the application
+                        CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
+                        """,
+                        """
+                        # Use a specific base image with Java installed
+                        FROM openjdk:21-jdk-slim
+
+                        # Set environment variables for Java paths
+                        ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+                        ENV PATH=$JAVA_HOME/bin:$PATH
+
+                        # Example RUN commands using hard-coded Java paths
+                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
+                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
+
+                        # Set the working directory
+                        WORKDIR /app
+
+                        # Copy application files into the container
+                        COPY . .
+
+                        # Compile the application
+                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
+
+                        # Command to run the application
+                        CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]"""
+                )
+        );
+    }
+
+    @Test
+    void replacesLiteralsWithinRun() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
+                dockerfile(
+                """
+                RUN python <<EOF > /hello
+                print("Hello")
+                print("World")
+                EOF
+                """,
+                """
+                RUN python3 <<EOF > /hello
+                print("Hello")
+                print("World")
+                EOF
+                """)
+                );
+
+    }
+
+    @Test
+    void replacesLiteralsWithinShell() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
+                dockerfile(
+                        """
+                        SHELL ["python", "-c"]
+                        RUN <<EOF > /hello
+                        print("Hello")
+                        print("World")
+                        EOF
+                        """,
+                        """
+                        SHELL ["python3", "-c"]
+                        RUN <<EOF > /hello
+                        print("Hello")
+                        print("World")
+                        EOF
+                        """)
+        );
+    }
+
+    @Test
+    void replacesLiteralsWithinHealthcheck() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyLiteral("python", "python3")),
+                dockerfile(
+                        "HEALTHCHECK CMD python -c 'print(\"Hello\")'",
+                        "HEALTHCHECK CMD python3 -c 'print(\"Hello\")'")
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
@@ -23,110 +23,110 @@ class ModifyLiteralTest implements RewriteTest {
     @Test
     void replacesAllMatchingLiterals() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyLiteral("(?:.*)(17)(?:(?=\\-jdk-slim|-openjdk).*)", "21")),
+          spec -> spec.recipe(new ModifyLiteral("(?:.*)(17)(?:(?=\\-jdk-slim|-openjdk).*)", "21")),
 
-                dockerfile(
-                        """
-                        # Use a specific base image with Java installed
-                        FROM openjdk:17-jdk-slim
+          dockerfile(
+            """
+            # Use a specific base image with Java installed
+            FROM openjdk:17-jdk-slim
 
-                        # Set environment variables for Java paths
-                        ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-                        ENV PATH=$JAVA_HOME/bin:$PATH
+            # Set environment variables for Java paths
+            ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+            ENV PATH=$JAVA_HOME/bin:$PATH
 
-                        # Example RUN commands using hard-coded Java paths
-                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
-                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
+            # Example RUN commands using hard-coded Java paths
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
 
-                        # Set the working directory
-                        WORKDIR /app
+            # Set the working directory
+            WORKDIR /app
 
-                        # Copy application files into the container
-                        COPY . .
+            # Copy application files into the container
+            COPY . .
 
-                        # Compile the application
-                        RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
+            # Compile the application
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
 
-                        # Command to run the application
-                        CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
-                        """,
-                        """
-                        # Use a specific base image with Java installed
-                        FROM openjdk:21-jdk-slim
+            # Command to run the application
+            CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
+            """,
+            """
+            # Use a specific base image with Java installed
+            FROM openjdk:21-jdk-slim
 
-                        # Set environment variables for Java paths
-                        ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-                        ENV PATH=$JAVA_HOME/bin:$PATH
+            # Set environment variables for Java paths
+            ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+            ENV PATH=$JAVA_HOME/bin:$PATH
 
-                        # Example RUN commands using hard-coded Java paths
-                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
-                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
+            # Example RUN commands using hard-coded Java paths
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
 
-                        # Set the working directory
-                        WORKDIR /app
+            # Set the working directory
+            WORKDIR /app
 
-                        # Copy application files into the container
-                        COPY . .
+            # Copy application files into the container
+            COPY . .
 
-                        # Compile the application
-                        RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
+            # Compile the application
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
 
-                        # Command to run the application
-                        CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]"""
-                )
+            # Command to run the application
+            CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]"""
+          )
         );
     }
 
     @Test
     void replacesLiteralsWithinRun() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
-                dockerfile(
-                """
-                RUN python <<EOF > /hello
-                print("Hello")
-                print("World")
-                EOF
-                """,
-                """
-                RUN python3 <<EOF > /hello
-                print("Hello")
-                print("World")
-                EOF
-                """)
-                );
+          spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
+          dockerfile(
+            """
+            RUN python <<EOF > /hello
+            print("Hello")
+            print("World")
+            EOF
+            """,
+            """
+            RUN python3 <<EOF > /hello
+            print("Hello")
+            print("World")
+            EOF
+            """)
+        );
 
     }
 
     @Test
     void replacesLiteralsWithinShell() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
-                dockerfile(
-                        """
-                        SHELL ["python", "-c"]
-                        RUN <<EOF > /hello
-                        print("Hello")
-                        print("World")
-                        EOF
-                        """,
-                        """
-                        SHELL ["python3", "-c"]
-                        RUN <<EOF > /hello
-                        print("Hello")
-                        print("World")
-                        EOF
-                        """)
+          spec -> spec.recipe(new ModifyLiteral("(?:.*)(python)(?:.*)", "python3")),
+          dockerfile(
+            """
+            SHELL ["python", "-c"]
+            RUN <<EOF > /hello
+            print("Hello")
+            print("World")
+            EOF
+            """,
+            """
+            SHELL ["python3", "-c"]
+            RUN <<EOF > /hello
+            print("Hello")
+            print("World")
+            EOF
+            """)
         );
     }
 
     @Test
     void replacesLiteralsWithinHealthcheck() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyLiteral("python", "python3")),
-                dockerfile(
-                        "HEALTHCHECK CMD python -c 'print(\"Hello\")'",
-                        "HEALTHCHECK CMD python3 -c 'print(\"Hello\")'")
+          spec -> spec.recipe(new ModifyLiteral("python", "python3")),
+          dockerfile(
+            "HEALTHCHECK CMD python -c 'print(\"Hello\")'",
+            "HEALTHCHECK CMD python3 -c 'print(\"Hello\")'")
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyLiteralTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
@@ -31,111 +31,111 @@ class ModifyOptionValueTest implements RewriteTest {
     @Test
     void modifyOptionValueOrMatchValue() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue("from", "build", "builder", null, false)),
-            //language=dockerfile
-            dockerfile(
-                "COPY --from=build /myapp /usr/bin/",
-                "COPY --from=builder /myapp /usr/bin/"
-            )
+          spec -> spec.recipe(new ModifyOptionValue("from", "build", "builder", null, false)),
+          //language=dockerfile
+          dockerfile(
+            "COPY --from=build /myapp /usr/bin/",
+            "COPY --from=builder /myapp /usr/bin/"
+          )
         );
     }
 
     @Test
     void modifyOptionValueWithoutParentIncludeKeyDashes() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", null, false)),
-                //language=dockerfile
-                dockerfile(
-                        "COPY --from=build /myapp /usr/bin/",
-                        "COPY --from=builder /myapp /usr/bin/"
-                )
+          spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", null, false)),
+          //language=dockerfile
+          dockerfile(
+            "COPY --from=build /myapp /usr/bin/",
+            "COPY --from=builder /myapp /usr/bin/"
+          )
         );
     }
 
     @Test
     void modifyOptionValueWrongParent() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", "ADD", false)),
-                //language=dockerfile
-                dockerfile(
-                        "COPY --from=build /myapp /usr/bin/"
-                )
+          spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", "ADD", false)),
+          //language=dockerfile
+          dockerfile(
+            "COPY --from=build /myapp /usr/bin/"
+          )
         );
     }
 
     @Test
     void modifyOptionValueWithParentAndRegex() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue(
-                        "from",
-                        "build",
-                        "other",
-                        "COPY.+/usr/bin/",
-                        true)),
-                //language=dockerfile
-                dockerfile(
-                        """
-                            COPY --from=build /myapp /usr/bin/
-                            COPY --from=builder /myapp /usr/local/bin/
-                            """,
-                        """
-                            COPY --from=other /myapp /usr/bin/
-                            COPY --from=builder /myapp /usr/local/bin/
-                            """
-                )
+          spec -> spec.recipe(new ModifyOptionValue(
+            "from",
+            "build",
+            "other",
+            "COPY.+/usr/bin/",
+            true)),
+          //language=dockerfile
+          dockerfile(
+            """
+            COPY --from=build /myapp /usr/bin/
+            COPY --from=builder /myapp /usr/local/bin/
+            """,
+            """
+            COPY --from=other /myapp /usr/bin/
+            COPY --from=builder /myapp /usr/local/bin/
+            """
+          )
         );
     }
 
     @Test
     void modifyOptionValueMatchSingleOption() {
         rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue(
-                        "mount",
-                        ".+/var/cache.+",
-                        "type=tmpfs,destination=/tmp,size=300M",
-                        "RUN",
-                        false)),
-                //language=dockerfile
-                dockerfile(
-                        """
-                            FROM ubuntu
-                            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-                            RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-                                --mount=type=cache,target=/var/lib/apt,sharing=locked \
-                                  apt update && apt-get --no-install-recommends install -y gcc
-                            """,
-                        """
-                            FROM ubuntu
-                            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-                            RUN --mount=type=tmpfs,destination=/tmp,size=300M \
-                                --mount=type=cache,target=/var/lib/apt,sharing=locked \
-                                  apt update && apt-get --no-install-recommends install -y gcc
-                            """
-                )
+          spec -> spec.recipe(new ModifyOptionValue(
+            "mount",
+            ".+/var/cache.+",
+            "type=tmpfs,destination=/tmp,size=300M",
+            "RUN",
+            false)),
+          //language=dockerfile
+          dockerfile(
+            """
+            FROM ubuntu
+            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+            RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+                --mount=type=cache,target=/var/lib/apt,sharing=locked \
+                  apt update && apt-get --no-install-recommends install -y gcc
+            """,
+            """
+            FROM ubuntu
+            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+            RUN --mount=type=tmpfs,destination=/tmp,size=300M \
+                --mount=type=cache,target=/var/lib/apt,sharing=locked \
+                  apt update && apt-get --no-install-recommends install -y gcc
+            """
+          )
         );
     }
 
     @Test
     void modifyOptionValueWithInvalidParent() {
         AssertionError assertionError = assertThrows(AssertionError.class, () -> rewriteRun(
-                spec -> spec.recipe(new ModifyOptionValue(
-                        "from",
-                        null,
-                        "other",
-                        "FROM",
-                        false)),
-                //language=dockerfile
-                dockerfile(
-                        """
-                            COPY --from=build /myapp /usr/bin/
-                            COPY --from=builder /myapp /usr/local/bin/
-                            """
-                )
+          spec -> spec.recipe(new ModifyOptionValue(
+            "from",
+            null,
+            "other",
+            "FROM",
+            false)),
+          //language=dockerfile
+          dockerfile(
+            """
+            COPY --from=build /myapp /usr/bin/
+            COPY --from=builder /myapp /usr/local/bin/
+            """
+          )
         ));
 
         assertThat(assertionError).cause().isInstanceOf(RecipeRunException.class);
         RecipeRunException e = (RecipeRunException) assertionError.getCause();
         assertThat(e.getMessage())
-                .contains("Invalid parent instruction: FROM");
+          .contains("Invalid parent instruction: FROM");
     }
 }

--- a/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
+++ b/src/test/java/org/openrewrite/docker/ModifyOptionValueTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.RecipeRunException;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ModifyOptionValueTest implements RewriteTest {
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.recipe(new ModifyOptionValue());
+    }
+
+    @Test
+    void modifyOptionValueOrMatchValue() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue("from", "build", "builder", null, false)),
+            //language=dockerfile
+            dockerfile(
+                "COPY --from=build /myapp /usr/bin/",
+                "COPY --from=builder /myapp /usr/bin/"
+            )
+        );
+    }
+
+    @Test
+    void modifyOptionValueWithoutParentIncludeKeyDashes() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", null, false)),
+                //language=dockerfile
+                dockerfile(
+                        "COPY --from=build /myapp /usr/bin/",
+                        "COPY --from=builder /myapp /usr/bin/"
+                )
+        );
+    }
+
+    @Test
+    void modifyOptionValueWrongParent() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue("--from", "build", "builder", "ADD", false)),
+                //language=dockerfile
+                dockerfile(
+                        "COPY --from=build /myapp /usr/bin/"
+                )
+        );
+    }
+
+    @Test
+    void modifyOptionValueWithParentAndRegex() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue(
+                        "from",
+                        "build",
+                        "other",
+                        "COPY.+/usr/bin/",
+                        true)),
+                //language=dockerfile
+                dockerfile(
+                        """
+                            COPY --from=build /myapp /usr/bin/
+                            COPY --from=builder /myapp /usr/local/bin/
+                            """,
+                        """
+                            COPY --from=other /myapp /usr/bin/
+                            COPY --from=builder /myapp /usr/local/bin/
+                            """
+                )
+        );
+    }
+
+    @Test
+    void modifyOptionValueMatchSingleOption() {
+        rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue(
+                        "mount",
+                        ".+/var/cache.+",
+                        "type=tmpfs,destination=/tmp,size=300M",
+                        "RUN",
+                        false)),
+                //language=dockerfile
+                dockerfile(
+                        """
+                            FROM ubuntu
+                            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+                            RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+                                --mount=type=cache,target=/var/lib/apt,sharing=locked \
+                                  apt update && apt-get --no-install-recommends install -y gcc
+                            """,
+                        """
+                            FROM ubuntu
+                            RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+                            RUN --mount=type=tmpfs,destination=/tmp,size=300M \
+                                --mount=type=cache,target=/var/lib/apt,sharing=locked \
+                                  apt update && apt-get --no-install-recommends install -y gcc
+                            """
+                )
+        );
+    }
+
+    @Test
+    void modifyOptionValueWithInvalidParent() {
+        AssertionError assertionError = assertThrows(AssertionError.class, () -> rewriteRun(
+                spec -> spec.recipe(new ModifyOptionValue(
+                        "from",
+                        null,
+                        "other",
+                        "FROM",
+                        false)),
+                //language=dockerfile
+                dockerfile(
+                        """
+                            COPY --from=build /myapp /usr/bin/
+                            COPY --from=builder /myapp /usr/local/bin/
+                            """
+                )
+        ));
+
+        assertThat(assertionError).cause().isInstanceOf(RecipeRunException.class);
+        RecipeRunException e = (RecipeRunException) assertionError.getCause();
+        assertThat(e.getMessage())
+                .contains("Invalid parent instruction: FROM");
+    }
+}

--- a/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
+++ b/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
+++ b/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class NameAllStagesTest implements RewriteTest {
+    @Test
+    void nameAllStages() {
+        rewriteRun(
+                spec -> spec.recipe(new NameAllStages()),
+                dockerfile(
+                        """
+                        # Stage 1: Build dependencies
+                        FROM ubuntu:20.04
+                        RUN apt-get update && apt-get install -y build-essential
+                        RUN echo "Stage 1 complete" > /stage1.txt
+
+                        # Stage 2: Build application
+                        FROM ubuntu:20.04
+                        COPY --from=0 /stage1.txt /stage2.txt
+                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+
+                        # Stage 3: Run tests
+                        FROM ubuntu:20.04
+                        COPY --from=1 /stage2_complete.txt /stage3.txt
+                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+
+                        # Final Stage: Create runtime image
+                        FROM ubuntu:20.04
+                        COPY --from=2 /stage3_complete.txt /final_stage.txt
+                        CMD ["cat", "/final_stage.txt"]
+                        """,
+                        """
+                        # Stage 1: Build dependencies
+                        FROM ubuntu:20.04 AS stage0
+                        RUN apt-get update && apt-get install -y build-essential
+                        RUN echo "Stage 1 complete" > /stage1.txt
+
+                        # Stage 2: Build application
+                        FROM ubuntu:20.04 AS stage1
+                        COPY --from=stage0 /stage1.txt /stage2.txt
+                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+
+                        # Stage 3: Run tests
+                        FROM ubuntu:20.04 AS stage2
+                        COPY --from=stage1 /stage2_complete.txt /stage3.txt
+                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+
+                        # Final Stage: Create runtime image
+                        FROM ubuntu:20.04
+                        COPY --from=stage2 /stage3_complete.txt /final_stage.txt
+                        CMD ["cat", "/final_stage.txt"]
+                        """)
+        );
+    }
+
+    @Test
+    void nameAllStagesMixed() {
+        rewriteRun(
+                spec -> spec.recipe(new NameAllStages()),
+                dockerfile(
+                        """
+                        # Stage 1: Build dependencies
+                        FROM ubuntu:20.04
+                        RUN apt-get update && apt-get install -y build-essential
+                        RUN echo "Stage 1 complete" > /stage1.txt
+
+                        # Stage 2: Build application
+                        FROM ubuntu:20.04 AS second
+                        COPY --from=0 /stage1.txt /stage2.txt
+                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+
+                        # Stage 3: Run tests
+                        FROM ubuntu:20.04
+                        COPY --from=second /stage2_complete.txt /stage3.txt
+                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+
+                        # Final Stage: Create runtime image
+                        FROM ubuntu:20.04
+                        COPY --from=2 /stage3_complete.txt /final_stage.txt
+                        CMD ["cat", "/final_stage.txt"]
+                        """,
+                        """
+                        # Stage 1: Build dependencies
+                        FROM ubuntu:20.04 AS stage0
+                        RUN apt-get update && apt-get install -y build-essential
+                        RUN echo "Stage 1 complete" > /stage1.txt
+
+                        # Stage 2: Build application
+                        FROM ubuntu:20.04 AS second
+                        COPY --from=stage0 /stage1.txt /stage2.txt
+                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+
+                        # Stage 3: Run tests
+                        FROM ubuntu:20.04 AS stage2
+                        COPY --from=second /stage2_complete.txt /stage3.txt
+                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+
+                        # Final Stage: Create runtime image
+                        FROM ubuntu:20.04
+                        COPY --from=stage2 /stage3_complete.txt /final_stage.txt
+                        CMD ["cat", "/final_stage.txt"]
+                        """)
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
+++ b/src/test/java/org/openrewrite/docker/NameAllStagesTest.java
@@ -23,100 +23,100 @@ class NameAllStagesTest implements RewriteTest {
     @Test
     void nameAllStages() {
         rewriteRun(
-                spec -> spec.recipe(new NameAllStages()),
-                dockerfile(
-                        """
-                        # Stage 1: Build dependencies
-                        FROM ubuntu:20.04
-                        RUN apt-get update && apt-get install -y build-essential
-                        RUN echo "Stage 1 complete" > /stage1.txt
+          spec -> spec.recipe(new NameAllStages()),
+          dockerfile(
+            """
+            # Stage 1: Build dependencies
+            FROM ubuntu:20.04
+            RUN apt-get update && apt-get install -y build-essential
+            RUN echo "Stage 1 complete" > /stage1.txt
 
-                        # Stage 2: Build application
-                        FROM ubuntu:20.04
-                        COPY --from=0 /stage1.txt /stage2.txt
-                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+            # Stage 2: Build application
+            FROM ubuntu:20.04
+            COPY --from=0 /stage1.txt /stage2.txt
+            RUN echo "Stage 2 complete" > /stage2_complete.txt
 
-                        # Stage 3: Run tests
-                        FROM ubuntu:20.04
-                        COPY --from=1 /stage2_complete.txt /stage3.txt
-                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+            # Stage 3: Run tests
+            FROM ubuntu:20.04
+            COPY --from=1 /stage2_complete.txt /stage3.txt
+            RUN echo "Stage 3 complete" > /stage3_complete.txt
 
-                        # Final Stage: Create runtime image
-                        FROM ubuntu:20.04
-                        COPY --from=2 /stage3_complete.txt /final_stage.txt
-                        CMD ["cat", "/final_stage.txt"]
-                        """,
-                        """
-                        # Stage 1: Build dependencies
-                        FROM ubuntu:20.04 AS stage0
-                        RUN apt-get update && apt-get install -y build-essential
-                        RUN echo "Stage 1 complete" > /stage1.txt
+            # Final Stage: Create runtime image
+            FROM ubuntu:20.04
+            COPY --from=2 /stage3_complete.txt /final_stage.txt
+            CMD ["cat", "/final_stage.txt"]
+            """,
+            """
+            # Stage 1: Build dependencies
+            FROM ubuntu:20.04 AS stage0
+            RUN apt-get update && apt-get install -y build-essential
+            RUN echo "Stage 1 complete" > /stage1.txt
 
-                        # Stage 2: Build application
-                        FROM ubuntu:20.04 AS stage1
-                        COPY --from=stage0 /stage1.txt /stage2.txt
-                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+            # Stage 2: Build application
+            FROM ubuntu:20.04 AS stage1
+            COPY --from=stage0 /stage1.txt /stage2.txt
+            RUN echo "Stage 2 complete" > /stage2_complete.txt
 
-                        # Stage 3: Run tests
-                        FROM ubuntu:20.04 AS stage2
-                        COPY --from=stage1 /stage2_complete.txt /stage3.txt
-                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+            # Stage 3: Run tests
+            FROM ubuntu:20.04 AS stage2
+            COPY --from=stage1 /stage2_complete.txt /stage3.txt
+            RUN echo "Stage 3 complete" > /stage3_complete.txt
 
-                        # Final Stage: Create runtime image
-                        FROM ubuntu:20.04
-                        COPY --from=stage2 /stage3_complete.txt /final_stage.txt
-                        CMD ["cat", "/final_stage.txt"]
-                        """)
+            # Final Stage: Create runtime image
+            FROM ubuntu:20.04
+            COPY --from=stage2 /stage3_complete.txt /final_stage.txt
+            CMD ["cat", "/final_stage.txt"]
+            """)
         );
     }
 
     @Test
     void nameAllStagesMixed() {
         rewriteRun(
-                spec -> spec.recipe(new NameAllStages()),
-                dockerfile(
-                        """
-                        # Stage 1: Build dependencies
-                        FROM ubuntu:20.04
-                        RUN apt-get update && apt-get install -y build-essential
-                        RUN echo "Stage 1 complete" > /stage1.txt
+          spec -> spec.recipe(new NameAllStages()),
+          dockerfile(
+            """
+            # Stage 1: Build dependencies
+            FROM ubuntu:20.04
+            RUN apt-get update && apt-get install -y build-essential
+            RUN echo "Stage 1 complete" > /stage1.txt
 
-                        # Stage 2: Build application
-                        FROM ubuntu:20.04 AS second
-                        COPY --from=0 /stage1.txt /stage2.txt
-                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+            # Stage 2: Build application
+            FROM ubuntu:20.04 AS second
+            COPY --from=0 /stage1.txt /stage2.txt
+            RUN echo "Stage 2 complete" > /stage2_complete.txt
 
-                        # Stage 3: Run tests
-                        FROM ubuntu:20.04
-                        COPY --from=second /stage2_complete.txt /stage3.txt
-                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+            # Stage 3: Run tests
+            FROM ubuntu:20.04
+            COPY --from=second /stage2_complete.txt /stage3.txt
+            RUN echo "Stage 3 complete" > /stage3_complete.txt
 
-                        # Final Stage: Create runtime image
-                        FROM ubuntu:20.04
-                        COPY --from=2 /stage3_complete.txt /final_stage.txt
-                        CMD ["cat", "/final_stage.txt"]
-                        """,
-                        """
-                        # Stage 1: Build dependencies
-                        FROM ubuntu:20.04 AS stage0
-                        RUN apt-get update && apt-get install -y build-essential
-                        RUN echo "Stage 1 complete" > /stage1.txt
+            # Final Stage: Create runtime image
+            FROM ubuntu:20.04
+            COPY --from=2 /stage3_complete.txt /final_stage.txt
+            CMD ["cat", "/final_stage.txt"]
+            """,
+            """
+            # Stage 1: Build dependencies
+            FROM ubuntu:20.04 AS stage0
+            RUN apt-get update && apt-get install -y build-essential
+            RUN echo "Stage 1 complete" > /stage1.txt
 
-                        # Stage 2: Build application
-                        FROM ubuntu:20.04 AS second
-                        COPY --from=stage0 /stage1.txt /stage2.txt
-                        RUN echo "Stage 2 complete" > /stage2_complete.txt
+            # Stage 2: Build application
+            FROM ubuntu:20.04 AS second
+            COPY --from=stage0 /stage1.txt /stage2.txt
+            RUN echo "Stage 2 complete" > /stage2_complete.txt
 
-                        # Stage 3: Run tests
-                        FROM ubuntu:20.04 AS stage2
-                        COPY --from=second /stage2_complete.txt /stage3.txt
-                        RUN echo "Stage 3 complete" > /stage3_complete.txt
+            # Stage 3: Run tests
+            FROM ubuntu:20.04 AS stage2
+            COPY --from=second /stage2_complete.txt /stage3.txt
+            RUN echo "Stage 3 complete" > /stage3_complete.txt
 
-                        # Final Stage: Create runtime image
-                        FROM ubuntu:20.04
-                        COPY --from=stage2 /stage3_complete.txt /final_stage.txt
-                        CMD ["cat", "/final_stage.txt"]
-                        """)
+            # Final Stage: Create runtime image
+            FROM ubuntu:20.04
+            COPY --from=stage2 /stage3_complete.txt /final_stage.txt
+            CMD ["cat", "/final_stage.txt"]
+            """)
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
@@ -23,53 +23,53 @@ class RemoveImagePlatformTest implements RewriteTest {
     @Test
     void removePlatformWithDefaultMatchSingleFrom() {
         rewriteRun(
-                spec -> spec.recipe(new RemoveImagePlatform(null)),
-                dockerfile(
-                        """
-                        FROM --platform=linux/amd64 myImage:latest
-                        """,
-                        """
-                        FROM myImage:latest
-                        """
-                )
+          spec -> spec.recipe(new RemoveImagePlatform(null)),
+          dockerfile(
+            """
+            FROM --platform=linux/amd64 myImage:latest
+            """,
+            """
+            FROM myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void removePlatformWithDefaultMatchMultipleFrom() {
         rewriteRun(
-                spec -> spec.recipe(new RemoveImagePlatform(null)),
-                dockerfile(
-                        """
-                        FROM --platform=linux/arm64 firstImage AS base
-                        FROM --platform=windows/amd64 secondImage
-                        """,
-                        """
-                        FROM firstImage AS base
-                        FROM secondImage
-                        """
-                )
+          spec -> spec.recipe(new RemoveImagePlatform(null)),
+          dockerfile(
+            """
+            FROM --platform=linux/arm64 firstImage AS base
+            FROM --platform=windows/amd64 secondImage
+            """,
+            """
+            FROM firstImage AS base
+            FROM secondImage
+            """
+          )
         );
     }
 
     @Test
     void removePlatformWithCustomMatcherMultipleFrom() {
         rewriteRun(
-                spec -> spec.recipe(new RemoveImagePlatform(".+t.*?Image")),
-                dockerfile(
-                        """
-                        FROM --platform=linux/arm64 firstImage AS first
-                        FROM --platform=windows/amd64 secondImage AS second
-                        FROM thirdImage AS third
-                        FROM --platform=linux/amd64 fourthImage
-                        """,
-                        """
-                        FROM firstImage AS first
-                        FROM --platform=windows/amd64 secondImage AS second
-                        FROM thirdImage AS third
-                        FROM fourthImage
-                        """
-                )
+          spec -> spec.recipe(new RemoveImagePlatform(".+t.*?Image")),
+          dockerfile(
+            """
+            FROM --platform=linux/arm64 firstImage AS first
+            FROM --platform=windows/amd64 secondImage AS second
+            FROM thirdImage AS third
+            FROM --platform=linux/amd64 fourthImage
+            """,
+            """
+            FROM firstImage AS first
+            FROM --platform=windows/amd64 secondImage AS second
+            FROM thirdImage AS third
+            FROM fourthImage
+            """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class RemoveImagePlatformTest implements RewriteTest {
+    @Test
+    void removePlatformWithDefaultMatchSingleFrom() {
+        rewriteRun(
+                spec -> spec.recipe(new RemoveImagePlatform(null)),
+                dockerfile(
+                        """
+                        FROM --platform=linux/amd64 myImage:latest
+                        """,
+                        """
+                        FROM myImage:latest
+                        """
+                )
+        );
+    }
+
+    @Test
+    void removePlatformWithDefaultMatchMultipleFrom() {
+        rewriteRun(
+                spec -> spec.recipe(new RemoveImagePlatform(null)),
+                dockerfile(
+                        """
+                        FROM --platform=linux/arm64 firstImage AS base
+                        FROM --platform=windows/amd64 secondImage
+                        """,
+                        """
+                        FROM firstImage AS base
+                        FROM secondImage
+                        """
+                )
+        );
+    }
+
+    @Test
+    void removePlatformWithCustomMatcherMultipleFrom() {
+        rewriteRun(
+                spec -> spec.recipe(new RemoveImagePlatform(".+t.*?Image")),
+                dockerfile(
+                        """
+                        FROM --platform=linux/arm64 firstImage AS first
+                        FROM --platform=windows/amd64 secondImage AS second
+                        FROM thirdImage AS third
+                        FROM --platform=linux/amd64 fourthImage
+                        """,
+                        """
+                        FROM firstImage AS first
+                        FROM --platform=windows/amd64 secondImage AS second
+                        FROM thirdImage AS third
+                        FROM fourthImage
+                        """
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/RemoveImagePlatformTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class SetImagePlatformTest implements RewriteTest {
+    @Test
+    void setPlatformWithDefaultMatchSingleFrom() {
+        rewriteRun(
+            spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
+            dockerfile(
+                """
+                FROM myImage:latest
+                """
+                ,
+                """
+                FROM --platform=linux/amd64 myImage:latest
+                """
+            )
+        );
+    }
+
+    @Test
+    void setPlatformWithDefaultMatchMultipleFrom() {
+        rewriteRun(
+            spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
+            dockerfile(
+                """
+                FROM --platform=linux/arm64 firstImage AS base
+                FROM --platform=windows/amd64 secondImage
+                """,
+                """
+                FROM --platform=linux/amd64 firstImage AS base
+                FROM --platform=linux/amd64 secondImage
+                """
+            )
+        );
+    }
+
+    @Test
+    void setPlatformWithCustomMultipleFrom() {
+        rewriteRun(
+                spec -> spec.recipe(new SetImagePlatform("linux/amd64", ".+dImage")),
+                dockerfile(
+                        """
+                        FROM --platform=linux/arm64 firstImage AS first
+                        FROM --platform=windows/amd64 secondImage AS second
+                        FROM thirdImage AS third
+                        FROM --platform=linux/amd64 fourthImage
+                        """,
+                        """
+                        FROM --platform=linux/arm64 firstImage AS first
+                        FROM --platform=linux/amd64 secondImage AS second
+                        FROM --platform=linux/amd64 thirdImage AS third
+                        FROM --platform=linux/amd64 fourthImage
+                        """
+                )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
+++ b/src/test/java/org/openrewrite/docker/SetImagePlatformTest.java
@@ -23,54 +23,54 @@ class SetImagePlatformTest implements RewriteTest {
     @Test
     void setPlatformWithDefaultMatchSingleFrom() {
         rewriteRun(
-            spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
-            dockerfile(
-                """
-                FROM myImage:latest
-                """
-                ,
-                """
-                FROM --platform=linux/amd64 myImage:latest
-                """
-            )
+          spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
+          dockerfile(
+            """
+            FROM myImage:latest
+            """
+            ,
+            """
+            FROM --platform=linux/amd64 myImage:latest
+            """
+          )
         );
     }
 
     @Test
     void setPlatformWithDefaultMatchMultipleFrom() {
         rewriteRun(
-            spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
-            dockerfile(
-                """
-                FROM --platform=linux/arm64 firstImage AS base
-                FROM --platform=windows/amd64 secondImage
-                """,
-                """
-                FROM --platform=linux/amd64 firstImage AS base
-                FROM --platform=linux/amd64 secondImage
-                """
-            )
+          spec -> spec.recipe(new SetImagePlatform("linux/amd64", null)),
+          dockerfile(
+            """
+            FROM --platform=linux/arm64 firstImage AS base
+            FROM --platform=windows/amd64 secondImage
+            """,
+            """
+            FROM --platform=linux/amd64 firstImage AS base
+            FROM --platform=linux/amd64 secondImage
+            """
+          )
         );
     }
 
     @Test
     void setPlatformWithCustomMultipleFrom() {
         rewriteRun(
-                spec -> spec.recipe(new SetImagePlatform("linux/amd64", ".+dImage")),
-                dockerfile(
-                        """
-                        FROM --platform=linux/arm64 firstImage AS first
-                        FROM --platform=windows/amd64 secondImage AS second
-                        FROM thirdImage AS third
-                        FROM --platform=linux/amd64 fourthImage
-                        """,
-                        """
-                        FROM --platform=linux/arm64 firstImage AS first
-                        FROM --platform=linux/amd64 secondImage AS second
-                        FROM --platform=linux/amd64 thirdImage AS third
-                        FROM --platform=linux/amd64 fourthImage
-                        """
-                )
+          spec -> spec.recipe(new SetImagePlatform("linux/amd64", ".+dImage")),
+          dockerfile(
+            """
+            FROM --platform=linux/arm64 firstImage AS first
+            FROM --platform=windows/amd64 secondImage AS second
+            FROM thirdImage AS third
+            FROM --platform=linux/amd64 fourthImage
+            """,
+            """
+            FROM --platform=linux/arm64 firstImage AS first
+            FROM --platform=linux/amd64 secondImage AS second
+            FROM --platform=linux/amd64 thirdImage AS third
+            FROM --platform=linux/amd64 fourthImage
+            """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
@@ -26,27 +26,27 @@ class ListImagesTest implements RewriteTest {
     @Test
     void listImages() {
         rewriteRun(
-                spec -> spec.recipe(new ListImages())
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .dataTableAsCsv(ImageUseReport.class,
-                        """
-                        sourcePath,image,tag,digest,platform,alias,stageNumber
-                        Dockerfile,alpine,latest,,,,0
-                        old.dockerfile,alpine,latest,,,build,0
-                        nested/Dockerfile,alpine,latest,,linux/amd64,build,0
-                        nested/Dockerfile,debian,latest,,,,1
-                        """),
-                dockerfile(
-                        "FROM alpine:latest",
-                        spec -> spec.path("Dockerfile")),
-                dockerfile(
-                        "FROM alpine:latest AS build",
-                        spec -> spec.path("old.dockerfile")),
-                dockerfile(
-                        """
-                        FROM --platform=linux/amd64 alpine:latest AS build
-                        FROM debian:latest
-                        """, spec -> spec.path("nested/Dockerfile"))
+          spec -> spec.recipe(new ListImages())
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .dataTableAsCsv(ImageUseReport.class,
+              """
+              sourcePath,image,tag,digest,platform,alias,stageNumber
+              Dockerfile,alpine,latest,,,,0
+              old.dockerfile,alpine,latest,,,build,0
+              nested/Dockerfile,alpine,latest,,linux/amd64,build,0
+              nested/Dockerfile,debian,latest,,,,1
+              """),
+          dockerfile(
+            "FROM alpine:latest",
+            spec -> spec.path("Dockerfile")),
+          dockerfile(
+            "FROM alpine:latest AS build",
+            spec -> spec.path("old.dockerfile")),
+          dockerfile(
+            """
+            FROM --platform=linux/amd64 alpine:latest AS build
+            FROM debian:latest
+            """, spec -> spec.path("nested/Dockerfile"))
         );
     }
 

--- a/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.analysis;
+
+import org.openrewrite.docker.table.ImageUseReport;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class ListImagesTest implements RewriteTest {
+
+    @Test
+    void listImages() {
+        rewriteRun(
+                spec -> spec.recipe(new ListImages())
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .dataTableAsCsv(ImageUseReport.class,
+                        """
+                        path,image,tag,digest,platform,alias,stageNumber
+                        Dockerfile,alpine,latest,,,,0
+                        old.dockerfile,alpine,latest,,,build,0
+                        nested/Dockerfile,alpine,latest,,linux/amd64,build,0
+                        nested/Dockerfile,debian,latest,,,,1
+                        """),
+                dockerfile(
+                        "FROM alpine:latest",
+                        spec -> spec.path("Dockerfile")),
+                dockerfile(
+                        "FROM alpine:latest AS build",
+                        spec -> spec.path("old.dockerfile")),
+                dockerfile(
+                        """
+                        FROM --platform=linux/amd64 alpine:latest AS build
+                        FROM debian:latest
+                        """, spec -> spec.path("nested/Dockerfile"))
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListImagesTest.java
@@ -30,7 +30,7 @@ class ListImagesTest implements RewriteTest {
                         .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
                         .dataTableAsCsv(ImageUseReport.class,
                         """
-                        path,image,tag,digest,platform,alias,stageNumber
+                        sourcePath,image,tag,digest,platform,alias,stageNumber
                         Dockerfile,alpine,latest,,,,0
                         old.dockerfile,alpine,latest,,,build,0
                         nested/Dockerfile,alpine,latest,,linux/amd64,build,0

--- a/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.analysis;
+
+import org.openrewrite.docker.table.RemoteFileReport;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class ListRemoteFilesTest implements RewriteTest {
+
+    @Test
+    void listRemoteFiles() {
+        rewriteRun(
+                spec -> spec.recipe(new ListRemoteFiles())
+                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+                        .dataTableAsCsv(RemoteFileReport.class,
+                                """
+                                path,url
+                                Dockerfile,"https://example.com/file.txt"
+                                old.containerfile,"https://example.com/file2.txt"
+                                """),
+                dockerfile("""
+                           FROM alpine:latest
+                           ADD https://example.com/file.txt /file.txt
+                           """,
+                        spec -> spec.path("Dockerfile")),
+                dockerfile("""
+                           FROM alpine:latest
+                           ADD https://example.com/file2.txt /file.txt
+                           """,
+                        spec -> spec.path("old.containerfile"))
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
@@ -30,7 +30,7 @@ class ListRemoteFilesTest implements RewriteTest {
                         .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
                         .dataTableAsCsv(RemoteFileReport.class,
                                 """
-                                path,url
+                                sourcePath,url
                                 Dockerfile,"https://example.com/file.txt"
                                 old.containerfile,"https://example.com/file2.txt"
                                 """),

--- a/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
@@ -26,24 +26,24 @@ class ListRemoteFilesTest implements RewriteTest {
     @Test
     void listRemoteFiles() {
         rewriteRun(
-                spec -> spec.recipe(new ListRemoteFiles())
-                        .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
-                        .dataTableAsCsv(RemoteFileReport.class,
-                                """
-                                sourcePath,url
-                                Dockerfile,"https://example.com/file.txt"
-                                old.containerfile,"https://example.com/file2.txt"
-                                """),
-                dockerfile("""
-                           FROM alpine:latest
-                           ADD https://example.com/file.txt /file.txt
-                           """,
-                        spec -> spec.path("Dockerfile")),
-                dockerfile("""
-                           FROM alpine:latest
-                           ADD https://example.com/file2.txt /file.txt
-                           """,
-                        spec -> spec.path("old.containerfile"))
+          spec -> spec.recipe(new ListRemoteFiles())
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .dataTableAsCsv(RemoteFileReport.class,
+              """
+              sourcePath,url
+              Dockerfile,"https://example.com/file.txt"
+              old.containerfile,"https://example.com/file2.txt"
+              """),
+          dockerfile("""
+                     FROM alpine:latest
+                     ADD https://example.com/file.txt /file.txt
+                     """,
+            spec -> spec.path("Dockerfile")),
+          dockerfile("""
+                     FROM alpine:latest
+                     ADD https://example.com/file2.txt /file.txt
+                     """,
+            spec -> spec.path("old.containerfile"))
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
+++ b/src/test/java/org/openrewrite/docker/analysis/ListRemoteFilesTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
+++ b/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class FixAlternateEnvSyntaxTest implements RewriteTest {
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.recipe(new FixAlternateEnvSyntax());
+    }
+
+    @Test
+    void fixEnvSyntax() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile(
+                "ENV key value",
+                "ENV key=value"
+            )
+        );
+    }
+
+    @Test
+    void fixEnvAlternateSyntaxExample() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile(
+                "ENV ONE TWO= THREE=world",
+                "ENV ONE=\"TWO= THREE=world\""
+            )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
+++ b/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
+++ b/src/test/java/org/openrewrite/docker/format/FixAlternateEnvSyntaxTest.java
@@ -28,22 +28,22 @@ class FixAlternateEnvSyntaxTest implements RewriteTest {
     @Test
     void fixEnvSyntax() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile(
-                "ENV key value",
-                "ENV key=value"
-            )
+          //language=dockerfile
+          dockerfile(
+            "ENV key value",
+            "ENV key=value"
+          )
         );
     }
 
     @Test
     void fixEnvAlternateSyntaxExample() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile(
-                "ENV ONE TWO= THREE=world",
-                "ENV ONE=\"TWO= THREE=world\""
-            )
+          //language=dockerfile
+          dockerfile(
+            "ENV ONE TWO= THREE=world",
+            "ENV ONE=\"TWO= THREE=world\""
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
+++ b/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
@@ -29,80 +29,80 @@ class UppercaseInstructionNamesTest implements RewriteTest {
     @Test
     void uppercaseFrom() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile("from ubuntu:latest", "FROM ubuntu:latest")
+          //language=dockerfile
+          dockerfile("from ubuntu:latest", "FROM ubuntu:latest")
         );
     }
 
     @Test
     void uppercaseRun() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile("run echo hello world", "RUN echo hello world")
+          //language=dockerfile
+          dockerfile("run echo hello world", "RUN echo hello world")
         );
     }
 
     @Test
     void uppercaseCmd() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile("cmd echo hello world", "CMD echo hello world")
+          //language=dockerfile
+          dockerfile("cmd echo hello world", "CMD echo hello world")
         );
     }
 
     @Test
     void uppercaseLabel() {
         rewriteRun(
-            //language=dockerfile
-            dockerfile("label version=1.0", "LABEL version=1.0")
+          //language=dockerfile
+          dockerfile("label version=1.0", "LABEL version=1.0")
         );
     }
 
     @Test
     void uppercaseWorkdir() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("workdir /app", "WORKDIR /app")
+          //language=dockerfile
+          dockerfile("workdir /app", "WORKDIR /app")
         );
     }
 
     @Test
     void uppercaseExpose() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("expose 8080", "EXPOSE 8080")
+          //language=dockerfile
+          dockerfile("expose 8080", "EXPOSE 8080")
         );
     }
 
     @Test
     void uppercaseEnv() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("env KEY=value", "ENV KEY=value")
+          //language=dockerfile
+          dockerfile("env KEY=value", "ENV KEY=value")
         );
     }
 
     @Test
     void uppercaseCopy() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("copy src dest", "COPY src dest")
+          //language=dockerfile
+          dockerfile("copy src dest", "COPY src dest")
         );
     }
 
     @Test
     void uppercaseAdd() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("add src dest", "ADD src dest")
+          //language=dockerfile
+          dockerfile("add src dest", "ADD src dest")
         );
     }
 
     @Test
     void uppercaseEntrypoint() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("entrypoint echo hello", "ENTRYPOINT echo hello")
+          //language=dockerfile
+          dockerfile("entrypoint echo hello", "ENTRYPOINT echo hello")
         );
     }
 
@@ -110,48 +110,48 @@ class UppercaseInstructionNamesTest implements RewriteTest {
     @Test
     void uppercaseVolume() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("volume /data", "VOLUME /data")
+          //language=dockerfile
+          dockerfile("volume /data", "VOLUME /data")
         );
     }
 
     @Test
     void uppercaseStopsignal() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("stopsignal SIGTERM", "STOPSIGNAL SIGTERM")
+          //language=dockerfile
+          dockerfile("stopsignal SIGTERM", "STOPSIGNAL SIGTERM")
         );
     }
 
     @Test
     void uppercaseShell() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("shell [\"/bin/bash\"]", "SHELL [\"/bin/bash\"]")
+          //language=dockerfile
+          dockerfile("shell [\"/bin/bash\"]", "SHELL [\"/bin/bash\"]")
         );
     }
 
     @Test
     void uppercaseHealthcheck() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("healthcheck CMD curl -f http://localhost/", "HEALTHCHECK CMD curl -f http://localhost/")
+          //language=dockerfile
+          dockerfile("healthcheck CMD curl -f http://localhost/", "HEALTHCHECK CMD curl -f http://localhost/")
         );
     }
 
     @Test
     void uppercaseArg() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("arg VERSION=latest", "ARG VERSION=latest")
+          //language=dockerfile
+          dockerfile("arg VERSION=latest", "ARG VERSION=latest")
         );
     }
 
     @Test
     void uppercaseOnbuild() {
         rewriteRun(
-                //language=dockerfile
-                dockerfile("onbuild RUN echo hello", "ONBUILD RUN echo hello")
+          //language=dockerfile
+          dockerfile("onbuild RUN echo hello", "ONBUILD RUN echo hello")
         );
     }
 

--- a/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
+++ b/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+
+class UppercaseInstructionNamesTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UppercaseInstructionNames());
+    }
+
+    @Test
+    void uppercaseFrom() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile("from ubuntu:latest", "FROM ubuntu:latest")
+        );
+    }
+
+    @Test
+    void uppercaseRun() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile("run echo hello world", "RUN echo hello world")
+        );
+    }
+
+    @Test
+    void uppercaseCmd() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile("cmd echo hello world", "CMD echo hello world")
+        );
+    }
+
+    @Test
+    void uppercaseLabel() {
+        rewriteRun(
+            //language=dockerfile
+            dockerfile("label version=1.0", "LABEL version=1.0")
+        );
+    }
+
+    @Test
+    void uppercaseWorkdir() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("workdir /app", "WORKDIR /app")
+        );
+    }
+
+    @Test
+    void uppercaseExpose() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("expose 8080", "EXPOSE 8080")
+        );
+    }
+
+    @Test
+    void uppercaseEnv() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("env KEY=value", "ENV KEY=value")
+        );
+    }
+
+    @Test
+    void uppercaseCopy() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("copy src dest", "COPY src dest")
+        );
+    }
+
+    @Test
+    void uppercaseAdd() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("add src dest", "ADD src dest")
+        );
+    }
+
+    @Test
+    void uppercaseEntrypoint() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("entrypoint echo hello", "ENTRYPOINT echo hello")
+        );
+    }
+
+
+    @Test
+    void uppercaseVolume() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("volume /data", "VOLUME /data")
+        );
+    }
+
+    @Test
+    void uppercaseStopsignal() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("stopsignal SIGTERM", "STOPSIGNAL SIGTERM")
+        );
+    }
+
+    @Test
+    void uppercaseShell() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("shell [\"/bin/bash\"]", "SHELL [\"/bin/bash\"]")
+        );
+    }
+
+    @Test
+    void uppercaseHealthcheck() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("healthcheck CMD curl -f http://localhost/", "HEALTHCHECK CMD curl -f http://localhost/")
+        );
+    }
+
+    @Test
+    void uppercaseArg() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("arg VERSION=latest", "ARG VERSION=latest")
+        );
+    }
+
+    @Test
+    void uppercaseOnbuild() {
+        rewriteRun(
+                //language=dockerfile
+                dockerfile("onbuild RUN echo hello", "ONBUILD RUN echo hello")
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
+++ b/src/test/java/org/openrewrite/docker/format/UppercaseInstructionNamesTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
@@ -29,17 +29,17 @@ public class DockerParserHelpers {
 
     public static Docker.Stage assertMultiStageWithChildCount(Docker.Document document, int expectedStageCount, int expectedStageChildCount) {
         assertNotNull(document,
-                "Expected document to be non-null but was null");
+          "Expected document to be non-null but was null");
         assertNotNull(document.getStages(),
-                "Expected document to have stages but was null");
+          "Expected document to have stages but was null");
         assertEquals(expectedStageCount, document.getStages().size(),
-                "Expected document to have " + expectedStageCount + " stage but was " + document.getStages().size());
+          "Expected document to have " + expectedStageCount + " stage but was " + document.getStages().size());
 
         Docker.Stage stage = document.getStages().get(0);
         assertNotNull(stage.getChildren(),
-                "Expected stage to have children but was null");
+          "Expected stage to have children but was null");
         assertEquals(expectedStageChildCount, stage.getChildren().size(),
-                "Expected stage to have " + expectedStageChildCount + " children but was " + stage.getChildren().size());
+          "Expected stage to have " + expectedStageChildCount + " children but was " + stage.getChildren().size());
         return stage;
     }
 
@@ -47,115 +47,115 @@ public class DockerParserHelpers {
         Docker.Literal value = comment.getText();
 
         assertEquals(expectedAfter, value.getTrailing().getWhitespace(),
-                "Expected Comment to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
+          "Expected Comment to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
         assertEquals(expectedText, value.getText(),
-                "Expected Comment text to be '" + expectedText + "' but was '" + value.getText() + "'");
+          "Expected Comment text to be '" + expectedText + "' but was '" + value.getText() + "'");
         assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
-                "Expected Comment prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+          "Expected Comment prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
     }
 
     public static void assertDirective(Docker.Directive directive, String expectedPrefix, String expectedKey, boolean hasEquals, String expectedValue, String expectedAfter) {
         DockerRightPadded<Docker.KeyArgs> value = directive.getDirective();
 
         assertNotNull(value.getElement(),
-                "Expected Directive to have an element but was null");
+          "Expected Directive to have an element but was null");
         assertEquals(expectedAfter, value.getAfter().getWhitespace(),
-                "Expected Directive to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+          "Expected Directive to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
         assertEquals(expectedKey, value.getElement().key(),
-                "Expected Directive key to be '" + expectedKey + "' but was '" + value.getElement().key() + "'");
+          "Expected Directive key to be '" + expectedKey + "' but was '" + value.getElement().key() + "'");
         assertEquals(hasEquals, value.getElement().isHasEquals(),
-                "Expected Directive hasEquals to be '" + hasEquals + "' but was '" + value.getElement().isHasEquals() + "'");
+          "Expected Directive hasEquals to be '" + hasEquals + "' but was '" + value.getElement().isHasEquals() + "'");
         assertEquals(expectedValue, value.getElement().value(),
-                "Expected Directive value to be '" + expectedValue + "' but was '" + value.getElement().value() + "'");
+          "Expected Directive value to be '" + expectedValue + "' but was '" + value.getElement().value() + "'");
         assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace(),
-                "Expected Directive prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getElement().getPrefix().getWhitespace()) + "'");
+          "Expected Directive prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getElement().getPrefix().getWhitespace()) + "'");
     }
 
     public static void assertRightPaddedArg(
-            DockerRightPadded<Docker.KeyArgs> value,
-            Quoting expectedQuoting,
-            String expectedPrefix,
-            String expectedKey,
-            boolean hasEquals,
-            String expectedValue,
-            String expectedAfter) {
+      DockerRightPadded<Docker.KeyArgs> value,
+      Quoting expectedQuoting,
+      String expectedPrefix,
+      String expectedKey,
+      boolean hasEquals,
+      String expectedValue,
+      String expectedAfter) {
         assertNotNull(value.getElement(),
-                "Expected KeyArgs to have an element but was null");
+          "Expected KeyArgs to have an element but was null");
 
         assertKeyArgs(value.getElement(), expectedQuoting, expectedPrefix, expectedKey, hasEquals, expectedValue);
 
         assertEquals(expectedAfter, value.getAfter().getWhitespace(),
-                "Expected KeyArgs to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+          "Expected KeyArgs to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
     }
 
     public static void assertKeyArgs(Docker.KeyArgs value, Quoting expectedQuoting, String expectedPrefix, String expectedKey, boolean hasEquals, String expectedValue) {
         assertNotNull(value, "Expected KeyArgs to have an element but was null");
 
         assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
-                "Expected KeyArgs prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + (value.getPrefix().getWhitespace()) + "'");
+          "Expected KeyArgs prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + (value.getPrefix().getWhitespace()) + "'");
 
         assertEquals(expectedKey, value.key(),
-                "Expected KeyArgs key to be '" + expectedKey + "' but was '" + value.key() + "'");
+          "Expected KeyArgs key to be '" + expectedKey + "' but was '" + value.key() + "'");
         assertEquals(hasEquals, value.isHasEquals(),
-                "Expected KeyArgs hasEquals to be '" + hasEquals + "' but was '" + value.isHasEquals() + "'");
+          "Expected KeyArgs hasEquals to be '" + hasEquals + "' but was '" + value.isHasEquals() + "'");
         assertEquals(expectedValue, value.value(),
-                "Expected KeyArgs value to be '" + expectedValue + "' but was '" + value.value() + "'");
+          "Expected KeyArgs value to be '" + expectedValue + "' but was '" + value.value() + "'");
         assertEquals(expectedQuoting, value.getQuoting(),
-                "Expected KeyArgs quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
+          "Expected KeyArgs quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
     }
 
     public static void assertRightPaddedLiteral(
-            DockerRightPadded<Docker.Literal> value,
-            Quoting expectedQuoting, String expectedPrefix,
-            String expectedText,
-            String expectedTrailing,
-            String expectedAfter) {
+      DockerRightPadded<Docker.Literal> value,
+      Quoting expectedQuoting, String expectedPrefix,
+      String expectedText,
+      String expectedTrailing,
+      String expectedAfter) {
         assertNotNull(value.getElement(),
-                "Expected DockerRightPadded to have an element but was null");
+          "Expected DockerRightPadded to have an element but was null");
         assertLiteral(value.getElement(), expectedQuoting, expectedPrefix, expectedText, expectedTrailing);
         assertEquals(expectedAfter, value.getAfter().getWhitespace(),
-                "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+          "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
     }
 
     public static void assertRightPaddedOption(
-            DockerRightPadded<Docker.Option> value,
-            Quoting expectedQuoting,
-            String expectedPrefix,
-            String expectedKey,
-            boolean expectedEqualsSign,
-            String expectedValue,
-            String expectedAfter) {
+      DockerRightPadded<Docker.Option> value,
+      Quoting expectedQuoting,
+      String expectedPrefix,
+      String expectedKey,
+      boolean expectedEqualsSign,
+      String expectedValue,
+      String expectedAfter) {
         assertNotNull(value.getElement(),
-                "Expected DockerRightPadded to have an element but was null");
+          "Expected DockerRightPadded to have an element but was null");
         assertOption(value.getElement(), expectedQuoting, expectedPrefix, expectedKey, expectedEqualsSign, expectedValue);
         assertEquals(expectedAfter, value.getAfter().getWhitespace(),
-                "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+          "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
     }
 
     public static void assertLiteral(
-            Docker.Literal value,
-            Quoting expectedQuoting, String expectedPrefix,
-            String expectedText,
-            String expectedTrailing) {
+      Docker.Literal value,
+      Quoting expectedQuoting, String expectedPrefix,
+      String expectedText,
+      String expectedTrailing) {
         assertNotNull(value);
         assertEquals(expectedText, value.getText(),
-                "Expected Literal text to be '" + expectedText + "' but was '" + value.getText() + "'");
+          "Expected Literal text to be '" + expectedText + "' but was '" + value.getText() + "'");
         assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
-                "Expected Literal prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+          "Expected Literal prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
         assertEquals(expectedQuoting, value.getQuoting(),
-                "Expected Literal quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
+          "Expected Literal quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
         assertEquals(expectedTrailing, value.getTrailing().getWhitespace(),
-                "Expected Literal trailing whitespace to be '" + printableWhiteSpace(expectedTrailing) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
+          "Expected Literal trailing whitespace to be '" + printableWhiteSpace(expectedTrailing) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
     }
 
     public static void assertOption(
-            Docker.Option value,
-            Quoting expectedQuoting, String expectedPrefix,
-            String expectedKey,
-            boolean expectedEqualsSign,
-            String expectedValue) {
+      Docker.Option value,
+      Quoting expectedQuoting, String expectedPrefix,
+      String expectedKey,
+      boolean expectedEqualsSign,
+      String expectedValue) {
         assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
-                "Expected Option prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+          "Expected Option prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
         assertKeyArgs(value.getKeyArgs(), expectedQuoting, "", expectedKey, expectedEqualsSign, expectedValue);
     }
 

--- a/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.DockerRightPadded;
+import org.openrewrite.docker.tree.Quoting;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DockerParserHelpers {
+
+    public static Docker.Stage assertSingleStageWithChildCount(Docker.Document document, int expectedStageChildCount) {
+        return assertMultiStageWithChildCount(document, 1, expectedStageChildCount);
+    }
+
+    public static Docker.Stage assertMultiStageWithChildCount(Docker.Document document, int expectedStageCount, int expectedStageChildCount) {
+        assertNotNull(document,
+                "Expected document to be non-null but was null");
+        assertNotNull(document.getStages(),
+                "Expected document to have stages but was null");
+        assertEquals(expectedStageCount, document.getStages().size(),
+                "Expected document to have " + expectedStageCount + " stage but was " + document.getStages().size());
+
+        Docker.Stage stage = document.getStages().get(0);
+        assertNotNull(stage.getChildren(),
+                "Expected stage to have children but was null");
+        assertEquals(expectedStageChildCount, stage.getChildren().size(),
+                "Expected stage to have " + expectedStageChildCount + " children but was " + stage.getChildren().size());
+        return stage;
+    }
+
+    public static void assertComment(Docker.Comment comment, String expectedPrefix, String expectedText, String expectedAfter) {
+        Docker.Literal value = comment.getText();
+
+        assertEquals(expectedAfter, value.getTrailing().getWhitespace(),
+                "Expected Comment to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
+        assertEquals(expectedText, value.getText(),
+                "Expected Comment text to be '" + expectedText + "' but was '" + value.getText() + "'");
+        assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
+                "Expected Comment prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+    }
+
+    public static void assertDirective(Docker.Directive directive, String expectedPrefix, String expectedKey, boolean hasEquals, String expectedValue, String expectedAfter) {
+        DockerRightPadded<Docker.KeyArgs> value = directive.getDirective();
+
+        assertNotNull(value.getElement(),
+                "Expected Directive to have an element but was null");
+        assertEquals(expectedAfter, value.getAfter().getWhitespace(),
+                "Expected Directive to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+        assertEquals(expectedKey, value.getElement().key(),
+                "Expected Directive key to be '" + expectedKey + "' but was '" + value.getElement().key() + "'");
+        assertEquals(hasEquals, value.getElement().isHasEquals(),
+                "Expected Directive hasEquals to be '" + hasEquals + "' but was '" + value.getElement().isHasEquals() + "'");
+        assertEquals(expectedValue, value.getElement().value(),
+                "Expected Directive value to be '" + expectedValue + "' but was '" + value.getElement().value() + "'");
+        assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace(),
+                "Expected Directive prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getElement().getPrefix().getWhitespace()) + "'");
+    }
+
+    public static void assertRightPaddedArg(
+            DockerRightPadded<Docker.KeyArgs> value,
+            Quoting expectedQuoting,
+            String expectedPrefix,
+            String expectedKey,
+            boolean hasEquals,
+            String expectedValue,
+            String expectedAfter) {
+        assertNotNull(value.getElement(),
+                "Expected KeyArgs to have an element but was null");
+
+        assertKeyArgs(value.getElement(), expectedQuoting, expectedPrefix, expectedKey, hasEquals, expectedValue);
+
+        assertEquals(expectedAfter, value.getAfter().getWhitespace(),
+                "Expected KeyArgs to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+    }
+
+    public static void assertKeyArgs(Docker.KeyArgs value, Quoting expectedQuoting, String expectedPrefix, String expectedKey, boolean hasEquals, String expectedValue) {
+        assertNotNull(value, "Expected KeyArgs to have an element but was null");
+
+        assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
+                "Expected KeyArgs prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + (value.getPrefix().getWhitespace()) + "'");
+
+        assertEquals(expectedKey, value.key(),
+                "Expected KeyArgs key to be '" + expectedKey + "' but was '" + value.key() + "'");
+        assertEquals(hasEquals, value.isHasEquals(),
+                "Expected KeyArgs hasEquals to be '" + hasEquals + "' but was '" + value.isHasEquals() + "'");
+        assertEquals(expectedValue, value.value(),
+                "Expected KeyArgs value to be '" + expectedValue + "' but was '" + value.value() + "'");
+        assertEquals(expectedQuoting, value.getQuoting(),
+                "Expected KeyArgs quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
+    }
+
+    public static void assertRightPaddedLiteral(
+            DockerRightPadded<Docker.Literal> value,
+            Quoting expectedQuoting, String expectedPrefix,
+            String expectedText,
+            String expectedTrailing,
+            String expectedAfter) {
+        assertNotNull(value.getElement(),
+                "Expected DockerRightPadded to have an element but was null");
+        assertLiteral(value.getElement(), expectedQuoting, expectedPrefix, expectedText, expectedTrailing);
+        assertEquals(expectedAfter, value.getAfter().getWhitespace(),
+                "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+    }
+
+    public static void assertRightPaddedOption(
+            DockerRightPadded<Docker.Option> value,
+            Quoting expectedQuoting,
+            String expectedPrefix,
+            String expectedKey,
+            boolean expectedEqualsSign,
+            String expectedValue,
+            String expectedAfter) {
+        assertNotNull(value.getElement(),
+                "Expected DockerRightPadded to have an element but was null");
+        assertOption(value.getElement(), expectedQuoting, expectedPrefix, expectedKey, expectedEqualsSign, expectedValue);
+        assertEquals(expectedAfter, value.getAfter().getWhitespace(),
+                "Expected DockerRightPadded to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
+    }
+
+    public static void assertLiteral(
+            Docker.Literal value,
+            Quoting expectedQuoting, String expectedPrefix,
+            String expectedText,
+            String expectedTrailing) {
+        assertNotNull(value);
+        assertEquals(expectedText, value.getText(),
+                "Expected Literal text to be '" + expectedText + "' but was '" + value.getText() + "'");
+        assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
+                "Expected Literal prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+        assertEquals(expectedQuoting, value.getQuoting(),
+                "Expected Literal quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
+        assertEquals(expectedTrailing, value.getTrailing().getWhitespace(),
+                "Expected Literal trailing whitespace to be '" + printableWhiteSpace(expectedTrailing) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
+    }
+
+    public static void assertOption(
+            Docker.Option value,
+            Quoting expectedQuoting, String expectedPrefix,
+            String expectedKey,
+            boolean expectedEqualsSign,
+            String expectedValue) {
+        assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
+                "Expected Option prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
+        assertKeyArgs(value.getKeyArgs(), expectedQuoting, "", expectedKey, expectedEqualsSign, expectedValue);
+    }
+
+    public static String printableWhiteSpace(String whitespace) {
+        return whitespace.replaceAll(" ", "·").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "→");
+    }
+}

--- a/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerParserHelpers.java
@@ -18,6 +18,7 @@ import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.DockerRightPadded;
 import org.openrewrite.docker.tree.Quoting;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DockerParserHelpers {

--- a/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
@@ -40,15 +40,15 @@ class DockerfileParserTest {
     void testHeaderStyleComments() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                #
-                # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
-                #
-                # PLEASE DO NOT EDIT IT DIRECTLY.
-                #
+          """
+          #
+          # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+          #
+          # PLEASE DO NOT EDIT IT DIRECTLY.
+          #
 
-                FROM alpine:3.21
-                """.getBytes(StandardCharsets.UTF_8)));
+          FROM alpine:3.21
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 6);
         assertComment((Docker.Comment) stage.getChildren().get(0), "", "", "");
@@ -69,13 +69,13 @@ class DockerfileParserTest {
     void testFlowerboxStyleComments() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                ################################################
-                # ####
-                # This is a comment
-                #####
-                ################################################
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          ################################################
+          # ####
+          # This is a comment
+          #####
+          ################################################
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 5);
         // note that this is one character less than the first line, because the first # is the "instruction"
@@ -818,11 +818,11 @@ class DockerfileParserTest {
     void testCopyWithHeredoc() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                COPY <<EOF /usr/share/nginx/html/index.html
-                (your index page goes here)
-                EOF
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          COPY <<EOF /usr/share/nginx/html/index.html
+          (your index page goes here)
+          EOF
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -860,11 +860,11 @@ class DockerfileParserTest {
     void testRunMultiline() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
-                  --mount=type=cache,target=/var/lib/apt,sharing=locked \\
-                  apt update && apt-get --no-install-recommends install -y gcc
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
+            --mount=type=cache,target=/var/lib/apt,sharing=locked \\
+            apt update && apt-get --no-install-recommends install -y gcc
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -897,12 +897,12 @@ class DockerfileParserTest {
     void testRunMultilineClearsContinuation() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN echo Hello \\
-                    World
-                # This is a comment
-                # This is another comment
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN echo Hello \\
+              World
+          # This is a comment
+          # This is another comment
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 3);
 
@@ -933,12 +933,12 @@ class DockerfileParserTest {
     void testRunWithHeredoc() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN <<EOF
-                apt-get update
-                apt-get install -y curl
-                EOF
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN <<EOF
+          apt-get update
+          apt-get install -y curl
+          EOF
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -970,13 +970,13 @@ class DockerfileParserTest {
     void testRunWithHereDocPythonExample() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN python3 <<EOF
-                with open("/hello", "w") as f:
-                    print("Hello", file=f)
-                    print("World", file=f)
-                EOF
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN python3 <<EOF
+          with open("/hello", "w") as f:
+              print("Hello", file=f)
+              print("World", file=f)
+          EOF
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -1009,12 +1009,12 @@ class DockerfileParserTest {
     void testRunWithHeredocRedirection() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN python3 <<EOF > /hello
-                print("Hello")
-                print("World")
-                EOF
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN python3 <<EOF > /hello
+          print("Hello")
+          print("World")
+          EOF
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -1037,12 +1037,12 @@ class DockerfileParserTest {
     void testRunWithHeredocAfterOtherCommands() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN echo Hello World <<EOF
-                apt-get update
-                apt-get install -y curl
-                EOF
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN echo Hello World <<EOF
+          apt-get update
+          apt-get install -y curl
+          EOF
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -1069,20 +1069,20 @@ class DockerfileParserTest {
     void testFullDockerfile() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                FROM alpine:latest
-                RUN echo Hello World
-                CMD echo Goodbye World
-                ENTRYPOINT [ "echo", "Hello" ]
-                EXPOSE 8080 8081 \\\n\t\t9999/udp
-                SHELL [ "powershell", "-Command" ]
-                USER root:admin
-                VOLUME [ "/var/log", "/var/log2" ]
-                WORKDIR /var/log
-                LABEL foo=bar baz=qux
-                STOPSIGNAL SIGKILL
-                HEALTHCHECK NONE
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          FROM alpine:latest
+          RUN echo Hello World
+          CMD echo Goodbye World
+          ENTRYPOINT [ "echo", "Hello" ]
+          EXPOSE 8080 8081 \\\n\t\t9999/udp
+          SHELL [ "powershell", "-Command" ]
+          USER root:admin
+          VOLUME [ "/var/log", "/var/log2" ]
+          WORKDIR /var/log
+          LABEL foo=bar baz=qux
+          STOPSIGNAL SIGKILL
+          HEALTHCHECK NONE
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 12);
 
@@ -1181,12 +1181,12 @@ class DockerfileParserTest {
     void handleMultipleNewlinesEOF() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN echo Hello World
+          """
+          RUN echo Hello World
 
 
 
-                """.getBytes(StandardCharsets.UTF_8)));
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
@@ -1204,12 +1204,12 @@ class DockerfileParserTest {
     void handleMultipleCRLFinEOF() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN echo Hello World
-                \r
-                \r
-                \r
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN echo Hello World
+          \r
+          \r
+          \r
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
@@ -1227,40 +1227,40 @@ class DockerfileParserTest {
         DockerfileParser parser = new DockerfileParser();
 
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                FROM ubuntu:20.04
-                RUN apt-get update && apt-get install -y build-essential
-                RUN echo "Stage 1 complete" > /stage1.txt
+          """
+          FROM ubuntu:20.04
+          RUN apt-get update && apt-get install -y build-essential
+          RUN echo "Stage 1 complete" > /stage1.txt
 
-                FROM ubuntu:20.04
-                COPY --from=0 /stage1.txt /stage2.txt
-                RUN echo "Stage 2 complete" > /stage2_complete.txt
+          FROM ubuntu:20.04
+          COPY --from=0 /stage1.txt /stage2.txt
+          RUN echo "Stage 2 complete" > /stage2_complete.txt
 
-                FROM ubuntu:20.04
-                COPY --from=1 /stage2_complete.txt /stage3.txt
-                RUN echo "Stage 3 complete" > /stage3_complete.txt
+          FROM ubuntu:20.04
+          COPY --from=1 /stage2_complete.txt /stage3.txt
+          RUN echo "Stage 3 complete" > /stage3_complete.txt
 
-                FROM ubuntu:20.04
-                COPY --from=2 /stage3_complete.txt /final_stage.txt
-                CMD ["cat", "/final_stage.txt"]
-                """.getBytes(StandardCharsets.UTF_8)));
+          FROM ubuntu:20.04
+          COPY --from=2 /stage3_complete.txt /final_stage.txt
+          CMD ["cat", "/final_stage.txt"]
+          """.getBytes(StandardCharsets.UTF_8)));
 
 
         assertNotNull(doc, "Expected document to be non-null but was null");
         assertNotNull(doc.getStages(),
-                "Expected document to have stages but was null");
+          "Expected document to have stages but was null");
         assertEquals(4, doc.getStages().size(),
-                "Expected document to have " + 4 + " stage but was " + doc.getStages().size());
+          "Expected document to have " + 4 + " stage but was " + doc.getStages().size());
 
         Docker.Stage stage = doc.getStages().get(0);
         assertNotNull(stage.getChildren(),
-                "Expected stage to have children but was null");
+          "Expected stage to have children but was null");
 
         for (Docker.Stage docStage : doc.getStages()) {
             assertNotNull(docStage.getChildren(),
-                    "Expected stage to have children but was null");
+              "Expected stage to have children but was null");
             assertEquals(3, docStage.getChildren().size(),
-                    "Expected every stage to have only 3 children but was " + stage.getChildren().size());
+              "Expected every stage to have only 3 children but was " + stage.getChildren().size());
         }
 
         Docker.Stage stage0 = doc.getStages().get(0);
@@ -1385,11 +1385,11 @@ class DockerfileParserTest {
     void testDockerfileWithCommentBetweenContinuationLines() {
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-                """
-                RUN echo Hello World \\
-                # This is a comment
-                && echo Goodbye World
-                """.getBytes(StandardCharsets.UTF_8)));
+          """
+          RUN echo Hello World \\
+          # This is a comment
+          && echo Goodbye World
+          """.getBytes(StandardCharsets.UTF_8)));
 
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
 
@@ -1418,12 +1418,12 @@ class DockerfileParserTest {
     @Test
     void testInstructionPrefixWithContinuationCommands() {
         String monster = """
-        ENV LAST_COMMIT=e2db71ff940a8b8c08c4ae894b952bfe7f0cf309
+                         ENV LAST_COMMIT=e2db71ff940a8b8c08c4ae894b952bfe7f0cf309
 
-        RUN set -eux; \\
-        	\\
-        	apk add --no-cache --virtual .build-deps
-        """;
+                         RUN set -eux; \\
+                         	\\
+                         	apk add --no-cache --virtual .build-deps
+                         """;
 
         DockerfileParser parser = new DockerfileParser();
         Docker.Document doc = parser.parse(new ByteArrayInputStream(monster.getBytes(StandardCharsets.UTF_8)));

--- a/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/DockerfileParserTest.java
@@ -1,0 +1,1448 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.openrewrite.docker.internal.DockerParserHelpers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DockerfileParserTest {
+    @Test
+    void testCommentSingleWithTrailingSpace() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("# This is a comment\t\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Comment comment = (Docker.Comment) stage.getChildren().get(0);
+        assertComment(comment, " ", "This is a comment", "\t\t");
+    }
+
+    @Test
+    void testHeaderStyleComments() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                #
+                # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+                #
+                # PLEASE DO NOT EDIT IT DIRECTLY.
+                #
+
+                FROM alpine:3.21
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 6);
+        assertComment((Docker.Comment) stage.getChildren().get(0), "", "", "");
+        assertComment((Docker.Comment) stage.getChildren().get(1), " ", "NOTE: THIS DOCKERFILE IS GENERATED VIA \"apply-templates.sh\"", "");
+        assertComment((Docker.Comment) stage.getChildren().get(2), "", "", "");
+        assertComment((Docker.Comment) stage.getChildren().get(3), " ", "PLEASE DO NOT EDIT IT DIRECTLY.", "");
+        assertComment((Docker.Comment) stage.getChildren().get(4), "", "", "");
+
+        Docker.From from = (Docker.From) stage.getChildren().get(5);
+        assertEquals(Space.EMPTY, from.getPrefix());
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertEquals("3.21", from.getTag());
+        assertEquals("", from.getImage().getTrailing().getWhitespace());
+        assertEquals(" ", from.getImage().getPrefix().getWhitespace());
+    }
+
+    @Test
+    void testFlowerboxStyleComments() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                ################################################
+                # ####
+                # This is a comment
+                #####
+                ################################################
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 5);
+        // note that this is one character less than the first line, because the first # is the "instruction"
+        assertComment((Docker.Comment) stage.getChildren().get(0), "", "###############################################", "");
+        assertComment((Docker.Comment) stage.getChildren().get(1), " ", "####", "");
+        assertComment((Docker.Comment) stage.getChildren().get(2), " ", "This is a comment", "");
+        // note the lack of the prefix space
+        assertComment((Docker.Comment) stage.getChildren().get(3), "", "####", "");
+        // note that this is one character less than the last line, because the first # is the "instruction"
+        assertComment((Docker.Comment) stage.getChildren().get(4), "", "###############################################", "");
+    }
+
+    @Test
+    void testRetainCarriageReturn() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("# This is a comment\t\t\r\n".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Comment comment = (Docker.Comment) stage.getChildren().get(0);
+        assertComment(comment, " ", "This is a comment", "\t\t");
+        assertEquals(printableWhiteSpace("\r\n"), printableWhiteSpace(doc.getEof().getWhitespace()));
+    }
+
+    @Test
+    void testDirective() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("#    syntax=docker/dockerfile:1".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Directive directive = (Docker.Directive) stage.getChildren().get(0);
+        assertDirective(directive, "    ", "syntax", true, "docker/dockerfile:1", "");
+    }
+
+    @Test
+    void testArgNoAssignment() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ARG foo".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, arg.getPrefix());
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", false, null, "");
+    }
+
+    @Test
+    void testArgNoAssignmentLowercased() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("arg foo".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        assertTrue(arg.getMarkers().findFirst(InstructionName.class).isPresent());
+
+        assertEquals(Space.EMPTY, arg.getPrefix());
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", false, null, "");
+    }
+
+    @Test
+    void testArgComplex() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ARG foo=bar baz MY_VAR OTHER_VAR=\"some default\" \t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, arg.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
+        assertEquals(4, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", "");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, " ", "baz", false, null, "");
+        assertRightPaddedArg(args.get(2), Quoting.UNQUOTED, " ", "MY_VAR", false, null, "");
+        assertRightPaddedArg(args.get(3), Quoting.DOUBLE_QUOTED, " ", "OTHER_VAR", true, "some default", " \t");
+    }
+
+    @Test
+    void testArgMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ARG foo=bar baz MY_VAR \\\nOTHER_VAR=\"some default\" \t\\\n\t\tLAST".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, arg.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
+        assertEquals(5, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", "");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, " ", "baz", false, null, "");
+        assertRightPaddedArg(args.get(2), Quoting.UNQUOTED, " ", "MY_VAR", false, null, " \\\n");
+        assertRightPaddedArg(args.get(3), Quoting.DOUBLE_QUOTED, "", "OTHER_VAR", true, "some default", " \t\\\n");
+        assertRightPaddedArg(args.get(4), Quoting.UNQUOTED, "\t\t", "LAST", false, null, "");
+    }
+
+    @Test
+    void testCmdComplexExecForm() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("CMD [ \"echo\", \"Hello World\" ]   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(2, args.size());
+
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ");
+
+        assertEquals(" ", cmd.getExecFormPrefix().getWhitespace());
+        assertEquals("   ", cmd.getExecFormSuffix().getWhitespace());
+    }
+
+    @Test
+    void testCmdShellForm() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("CMD echo Hello World   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
+    }
+
+    @Test
+    void testCmdShellFormWithQuotes() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("CMD \"echo Hello World\"   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(1, args.size());
+
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "   ");
+        assertEquals("", cmd.getExecFormSuffix().getWhitespace());
+        assertEquals("", cmd.getExecFormPrefix().getWhitespace());
+    }
+
+    @Test
+    void testCmdShellWithoutQuotes() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("CMD echo Hello World   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
+    }
+
+    @Test
+    void testEntrypointComplexExecForm() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT [ \"echo\", \"Hello World\" ]   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+
+        List<Docker.Literal> args = entrypoint.getCommands();
+        assertEquals(2, args.size());
+
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ");
+
+        assertEquals("   ", entrypoint.getExecFormSuffix().getWhitespace());
+    }
+
+    @Test
+    void testEntrypointShellForm() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT echo Hello World   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+
+        List<Docker.Literal> args = entrypoint.getCommands();
+        assertEquals(3, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
+    }
+
+    @Test
+    void testEntrypointShellFormWithQuotes() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT \"echo Hello World\"   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+
+        List<Docker.Literal> args = entrypoint.getCommands();
+        assertEquals(1, args.size());
+
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "   ");
+    }
+
+    @Test
+    void testEnvAlternateSyntax() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENV MY_NAME Jim".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Env env = (Docker.Env) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, env.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = env.getArgs();
+        assertEquals(1, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "MY_NAME", false, "Jim", "");
+    }
+
+    @Test
+    void testEnvAlternateSyntaxDocumentedCaveat() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENV ONE TWO= THREE=world".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Env env = (Docker.Env) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, env.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = env.getArgs();
+        assertEquals(1, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "ONE", false, "TWO= THREE=world", "");
+    }
+
+    @Test
+    void testEnvComplex() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENV MY_NAME=\"John Doe\" MY_DOG=Rex\\ The\\ Dog MY_CAT=fluffy".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Env env = (Docker.Env) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, env.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = env.getArgs();
+        assertEquals(3, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.DOUBLE_QUOTED, " ", "MY_NAME", true, "John Doe", "");
+        assertRightPaddedArg(args.get(2), Quoting.UNQUOTED, " ", "MY_CAT", true, "fluffy", "");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, " ", "MY_DOG", true, "Rex The Dog", "");
+    }
+
+    @Test
+    void testEnvMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ENV MY_NAME=\"John Doe\" MY_DOG=Rex\\ The\\ Dog \\\nMY_CAT=fluffy ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Env env = (Docker.Env) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, env.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = env.getArgs();
+        assertEquals(3, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.DOUBLE_QUOTED, " ", "MY_NAME", true, "John Doe", "");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, " ", "MY_DOG", true, "Rex The Dog", " \\\n");
+        assertRightPaddedArg(args.get(2), Quoting.UNQUOTED, "", "MY_CAT", true, "fluffy", " ");
+    }
+
+    @Test
+    void testExposeSingle() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("EXPOSE 8080".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Expose expose = (Docker.Expose) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, expose.getPrefix());
+
+        List<DockerRightPadded<Docker.Port>> ports = expose.getPorts();
+        assertEquals(1, ports.size());
+        assertEquals("8080", ports.get(0).getElement().getPort());
+        assertEquals(" ", ports.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals("", ports.get(0).getAfter().getWhitespace());
+        assertEquals("tcp", ports.get(0).getElement().getProtocol());
+    }
+
+    @Test
+    void testExposeMultiple() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("EXPOSE 8080 8081/udp 9999".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Expose expose = (Docker.Expose) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, expose.getPrefix());
+
+        List<DockerRightPadded<Docker.Port>> ports = expose.getPorts();
+        assertEquals(3, ports.size());
+        assertEquals("8080", ports.get(0).getElement().getPort());
+        assertEquals(" ", ports.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals("", ports.get(0).getAfter().getWhitespace());
+        assertEquals("tcp", ports.get(0).getElement().getProtocol());
+
+        assertEquals("8081", ports.get(1).getElement().getPort());
+        assertEquals(" ", ports.get(1).getElement().getPrefix().getWhitespace());
+        assertEquals("", ports.get(1).getAfter().getWhitespace());
+        assertEquals("udp", ports.get(1).getElement().getProtocol());
+
+        assertEquals("9999", ports.get(2).getElement().getPort());
+        assertEquals(" ", ports.get(2).getElement().getPrefix().getWhitespace());
+        assertEquals("", ports.get(2).getAfter().getWhitespace());
+        assertEquals("tcp", ports.get(2).getElement().getProtocol());
+    }
+
+    @Test
+    void testExposeMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("EXPOSE 8080 \\\n\t\t8081/udp \\\n9999".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Expose expose = (Docker.Expose) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, expose.getPrefix());
+
+        List<DockerRightPadded<Docker.Port>> ports = expose.getPorts();
+        assertEquals(3, ports.size());
+        assertEquals("8080", ports.get(0).getElement().getPort());
+        assertEquals(" ", ports.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals(" \\\n", ports.get(0).getAfter().getWhitespace());
+        assertEquals("tcp", ports.get(0).getElement().getProtocol());
+
+        assertEquals("8081", ports.get(1).getElement().getPort());
+        assertEquals("\t\t", ports.get(1).getElement().getPrefix().getWhitespace());
+        assertEquals(" \\\n", ports.get(1).getAfter().getWhitespace());
+        assertEquals("udp", ports.get(1).getElement().getProtocol());
+
+        assertEquals("9999", ports.get(2).getElement().getPort());
+        assertEquals("", ports.get(2).getElement().getPrefix().getWhitespace());
+        assertEquals("", ports.get(2).getAfter().getWhitespace());
+        assertEquals("tcp", ports.get(2).getElement().getProtocol());
+    }
+
+    @Test
+    void testFrom() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("FROM alpine:latest".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.From from = (Docker.From) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, from.getPrefix());
+
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertEquals("latest", from.getTag());
+        assertEquals("", from.getImage().getTrailing().getWhitespace());
+    }
+
+    @Test
+    void testFullFrom() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("FROM --platform=linux/arm64 alpine:latest as build\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.From from = (Docker.From) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, from.getPrefix());
+
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, " ", "--platform=linux/arm64", "");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertEquals("latest", from.getTag());
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "");
+        assertLiteral(from.getAs(), Quoting.UNQUOTED, " ", "as", "");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, " ", "build", "\t");
+    }
+
+    @Test
+    void testFullFromWithDigest() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("FROM alpine@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.From from = (Docker.From) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, from.getPrefix());
+
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "\t");
+        assertEquals("sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", from.getDigest());
+    }
+
+    @Test
+    void testShell() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("SHELL [  \"powershell\", \"-Command\"   ]\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Shell shell = (Docker.Shell) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, shell.getPrefix());
+
+        List<Docker.Literal> commands = shell.getCommands();
+        assertEquals(2, commands.size());
+
+        assertLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", "   ");
+
+        assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
+        assertEquals("\t", shell.getExecFormSuffix().getWhitespace());
+    }
+
+    @Test
+    void testShellMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("SHELL [  \"powershell\", \"-Command\" , \t\\\n\t\t  \"bash\", \"-c\"   ]".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Shell shell = (Docker.Shell) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, shell.getPrefix());
+
+        List<Docker.Literal> commands = shell.getCommands();
+        assertEquals(4, commands.size());
+
+        assertLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", "  \t\\\n\t\t  ");
+        assertLiteral(commands.get(2), Quoting.DOUBLE_QUOTED, "", "bash", "");
+        assertLiteral(commands.get(3), Quoting.DOUBLE_QUOTED, " ", "-c", "   ");
+
+        assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
+        assertEquals("", shell.getExecFormSuffix().getWhitespace());
+    }
+
+    @Test
+    void testUserOnly() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("USER root".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.User user = (Docker.User) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, user.getPrefix());
+        assertLiteral(user.getUsername(), Quoting.UNQUOTED, " ", "root", "");
+        assertNull(user.getGroup());
+    }
+
+    @Test
+    void testUserWithGroup() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("USER root:admin".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.User user = (Docker.User) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, user.getPrefix());
+        assertLiteral(user.getUsername(), Quoting.UNQUOTED, " ", "root", "");
+        assertLiteral(user.getGroup(), Quoting.UNQUOTED, "", "admin", "");
+    }
+
+    @Test
+    void testUserWithFunkySpacing() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("USER    root:admin   \t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.User user = (Docker.User) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, user.getPrefix());
+        assertLiteral(user.getUsername(), Quoting.UNQUOTED, "    ", "root", "");
+        assertLiteral(user.getGroup(), Quoting.UNQUOTED, "", "admin", "   \t");
+    }
+
+    @Test
+    void testVolumeShellFormat() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("VOLUME [ \"/var/log\", \"/var/log2\" ]\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Volume volume = (Docker.Volume) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, volume.getPrefix());
+        assertEquals(" ", volume.getExecFormPrefix().getWhitespace());
+        assertEquals("\t", volume.getExecFormSuffix().getWhitespace());
+
+        List<Docker.Literal> args = volume.getPaths();
+        assertEquals(2, args.size());
+
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ");
+    }
+
+    @Test
+    void testVolumeExecFormat() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("VOLUME /var/log /var/log2\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Volume volume = (Docker.Volume) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, volume.getPrefix());
+        assertEquals("", volume.getExecFormPrefix().getWhitespace());
+        assertEquals("", volume.getExecFormSuffix().getWhitespace());
+
+        List<Docker.Literal> args = volume.getPaths();
+        assertEquals(2, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "/var/log", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/var/log2", "\t");
+    }
+
+    @Test
+    void testWorkDir() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("WORKDIR /var/log\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Workdir workdir = (Docker.Workdir) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, workdir.getPrefix());
+        assertLiteral(workdir.getPath(), Quoting.UNQUOTED, " ", "/var/log", ""); // TODO: FIX missing traililng here.
+    }
+
+    @Test
+    void testLabelSingle() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("LABEL foo=bar".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Label label = (Docker.Label) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, label.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = label.getArgs();
+        assertEquals(1, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", "");
+    }
+
+    @Test
+    void testLabelMultiple() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("LABEL foo=bar baz=qux".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Label label = (Docker.Label) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, label.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = label.getArgs();
+        assertEquals(2, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", "");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, " ", "baz", true, "qux", "");
+    }
+
+    @Test
+    void testLabelMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("LABEL foo=bar \\\n\t\tbaz=qux \\\n\t\tquux=\"Hello World\"".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Label label = (Docker.Label) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, label.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = label.getArgs();
+        assertEquals(3, args.size());
+
+        assertRightPaddedArg(args.get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", " \\\n");
+        assertRightPaddedArg(args.get(1), Quoting.UNQUOTED, "\t\t", "baz", true, "qux", " \\\n");
+        assertRightPaddedArg(args.get(2), Quoting.DOUBLE_QUOTED, "\t\t", "quux", true, "Hello World", "");
+    }
+
+
+    @Test
+    void testStopSignal() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("STOPSIGNAL SIGKILL".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.StopSignal stopSignal = (Docker.StopSignal) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, stopSignal.getPrefix());
+        assertLiteral(stopSignal.getSignal(), Quoting.UNQUOTED, " ", "SIGKILL", "");
+    }
+
+    @Test
+    void testHealthCheckNone() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("HEALTHCHECK NONE".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Healthcheck healthCheck = (Docker.Healthcheck) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, healthCheck.getPrefix());
+
+        List<Docker.Literal> commands = healthCheck.getCommands();
+        assertEquals(1, commands.size());
+
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "NONE", "");
+    }
+
+    @Test
+    void testHealthCheckWithCmd() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("HEALTHCHECK --interval=5m --timeout=3s \\\n  CMD curl -f http://localhost/ || exit 1".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Healthcheck healthCheck = (Docker.Healthcheck) stage.getChildren().get(0);
+        assertEquals("", healthCheck.getPrefix().getWhitespace());
+
+        List<DockerRightPadded<Docker.KeyArgs>> options = healthCheck.getOptions();
+        assertEquals(2, options.size());
+
+        assertRightPaddedArg(options.get(0), Quoting.UNQUOTED, " ", "--interval", true, "5m", "");
+        assertRightPaddedArg(options.get(1), Quoting.UNQUOTED, " ", "--timeout", true, "3s", " \\\n");
+
+        List<Docker.Literal> commands = healthCheck.getCommands();
+        assertEquals(7, commands.size());
+
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, "  ", "CMD", "");
+        assertLiteral(commands.get(1), Quoting.UNQUOTED, " ", "curl", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", "-f", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "http://localhost/", "");
+        assertLiteral(commands.get(4), Quoting.UNQUOTED, " ", "||", "");
+        assertLiteral(commands.get(5), Quoting.UNQUOTED, " ", "exit", "");
+        assertLiteral(commands.get(6), Quoting.UNQUOTED, " ", "1", "");
+    }
+
+    @Test
+    void testAdd() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ADD foo.txt \\\n\t\tbar.txt \\\n\t\tbaz.txt \\\n\t\tqux.txt /tmp/\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Add add = (Docker.Add) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, add.getPrefix());
+
+        List<Docker.Literal> args = add.getSources();
+        assertEquals(4, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
+
+        Docker.Literal dest = add.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
+    }
+
+    @Test
+    void testAddWithOptions() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("ADD --chown=foo:bar --keep-git-dir --checksum=sha256:24454f830c foo.txt \\\n\t\tbar.txt \\\n\t\tbaz.txt \\\n\t\tqux.txt /tmp/\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Add add = (Docker.Add) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, add.getPrefix());
+
+        List<Docker.Literal> args = add.getSources();
+        assertEquals(4, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
+
+        Docker.Literal dest = add.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
+
+        List<Docker.Option> options = add.getOptions();
+        assertEquals(3, options.size());
+        assertOption(options.get(0), Quoting.UNQUOTED, " ", "--chown", true, "foo:bar");
+        assertOption(options.get(1), Quoting.UNQUOTED, " ", "--keep-git-dir", false, null);
+        assertOption(options.get(2), Quoting.UNQUOTED, " ", "--checksum", true, "sha256:24454f830c");
+    }
+
+    @Test
+    void testCopy() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("COPY foo.txt \\\n\t\tbar.txt \\\n\t\tbaz.txt \\\n\t\tqux.txt /tmp/\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Copy copy = (Docker.Copy) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, copy.getPrefix());
+
+        List<Docker.Literal> args = copy.getSources();
+        assertEquals(4, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
+
+        Docker.Literal dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
+    }
+
+    /**
+     * Tests this example heredoc from docker blog @ <a href="https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/">...</a>
+     * COPY <<EOF /usr/share/nginx/html/index.html
+     * (your index page goes here)
+     * EOF
+     */
+    @Test
+    void testCopyWithHeredoc() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                COPY <<EOF /usr/share/nginx/html/index.html
+                (your index page goes here)
+                EOF
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Copy cmd = (Docker.Copy) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getSources();
+        assertEquals(4, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/usr/share/nginx/html/index.html", "\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "(your index page goes here)", "\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "EOF", "\n");
+    }
+
+    @Test
+    void testRun() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream("RUN echo Hello World\t".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "\t");
+    }
+
+    @Test
+    void testRunMultiline() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
+                  --mount=type=cache,target=/var/lib/apt,sharing=locked \\
+                  apt update && apt-get --no-install-recommends install -y gcc
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Option> opts = cmd.getOptions();
+        assertEquals(2, opts.size());
+
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--mount", true, "type=cache,target=/var/cache/apt,sharing=locked");
+        assertEquals(" \\\n", opts.get(0).getTrailing().getWhitespace());
+
+        assertOption(opts.get(1), Quoting.UNQUOTED, "  ", "--mount", true, "type=cache,target=/var/lib/apt,sharing=locked");
+        assertEquals(" \\\n", opts.get(1).getTrailing().getWhitespace());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(8, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, "  ", "apt", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "update", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "&&", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "--no-install-recommends", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "gcc", "");
+    }
+
+    @Test
+    void testRunMultilineClearsContinuation() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN echo Hello \\
+                    World
+                # This is a comment
+                # This is another comment
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 3);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", " \\\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "    ", "World", "");
+
+        Docker.Comment comment1 = (Docker.Comment) stage.getChildren().get(1);
+        assertLiteral(comment1.getText(), Quoting.UNQUOTED, " ", "This is a comment", "");
+        Docker.Comment comment2 = (Docker.Comment) stage.getChildren().get(2);
+        assertLiteral(comment2.getText(), Quoting.UNQUOTED, " ", "This is another comment", "");
+    }
+
+    /**
+     * Test this example heredoc from the Dockerfile reference:
+     * RUN <<EOF
+     * apt-get update
+     * apt-get install -y curl
+     * EOF
+     */
+    @Test
+    void testRunWithHeredoc() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN <<EOF
+                apt-get update
+                apt-get install -y curl
+                EOF
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(8, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "update", "\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "curl", "\n");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, "", "EOF", "\n");
+    }
+
+    /**
+     * Tests this example from docker blog @ <a href="https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/">...</a>
+     * RUN python3 <<EOF
+     * with open("/hello", "w") as f:
+     * print("Hello", file=f)
+     * print("World", file=f)
+     * EOF
+     */
+    @Test
+    void testRunWithHereDocPythonExample() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN python3 <<EOF
+                with open("/hello", "w") as f:
+                    print("Hello", file=f)
+                    print("World", file=f)
+                EOF
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(9, args.size());
+
+        // TODO: within heredocs, collect literals wrapped via () and [] along with single and double quoted strings
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "with", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "open(\"/hello\", \"w\")", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "as", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "f:", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "    ", "print(\"Hello\", file=f)", "\n");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, "    ", "print(\"World\", file=f)", "\n");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, "", "EOF", "\n");
+    }
+
+    /**
+     * Tests this example heredoc from docker blog @ <a href="https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/">...</a>
+     * RUN python3 <<EOF > /hello
+     * print("Hello")
+     * print("World")
+     * EOF
+     */
+    @Test
+    void testRunWithHeredocRedirection() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN python3 <<EOF > /hello
+                print("Hello")
+                print("World")
+                EOF
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(7, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "/hello", "\n");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, "", "print(\"Hello\")", "\n");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, "", "print(\"World\")", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "", "EOF", "\n");
+    }
+
+    @Test
+    void testRunWithHeredocAfterOtherCommands() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN echo Hello World <<EOF
+                apt-get update
+                apt-get install -y curl
+                EOF
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(11, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "update", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(9), Quoting.UNQUOTED, " ", "curl", "\n");
+        assertLiteral(args.get(10), Quoting.UNQUOTED, "", "EOF", "\n");
+    }
+
+    @Test
+    void testFullDockerfile() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                FROM alpine:latest
+                RUN echo Hello World
+                CMD echo Goodbye World
+                ENTRYPOINT [ "echo", "Hello" ]
+                EXPOSE 8080 8081 \\\n\t\t9999/udp
+                SHELL [ "powershell", "-Command" ]
+                USER root:admin
+                VOLUME [ "/var/log", "/var/log2" ]
+                WORKDIR /var/log
+                LABEL foo=bar baz=qux
+                STOPSIGNAL SIGKILL
+                HEALTHCHECK NONE
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 12);
+
+        Docker.From from = (Docker.From) stage.getChildren().get(0);
+
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "");
+        assertEquals("latest", from.getTag());
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from.getAs(), Quoting.UNQUOTED, "", null, "");
+
+        Docker.Run run = (Docker.Run) stage.getChildren().get(1);
+        assertEquals(Space.EMPTY, run.getPrefix());
+        assertLiteral(run.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(run.getCommands().get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(run.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "");
+
+
+        Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(2);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+        assertLiteral(cmd.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(cmd.getCommands().get(1), Quoting.UNQUOTED, " ", "Goodbye", "");
+        assertLiteral(cmd.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "");
+
+        Docker.Entrypoint entryPoint = (Docker.Entrypoint) stage.getChildren().get(3);
+        assertEquals(Space.EMPTY, entryPoint.getPrefix());
+        assertEquals(2, entryPoint.getCommands().size());
+        assertEquals(Form.EXEC, entryPoint.getForm());
+        assertLiteral(entryPoint.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(entryPoint.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "Hello", " ");
+        assertEquals(" ", entryPoint.getExecFormPrefix().getWhitespace());
+        assertEquals("", entryPoint.getExecFormSuffix().getWhitespace());
+
+        Docker.Expose expose = (Docker.Expose) stage.getChildren().get(4);
+        assertEquals(Space.EMPTY, expose.getPrefix());
+        assertEquals(" ", expose.getPorts().get(0).getElement().getPrefix().getWhitespace());
+        assertEquals("8080", expose.getPorts().get(0).getElement().getPort());
+        assertEquals("tcp", expose.getPorts().get(0).getElement().getProtocol());
+        assertFalse(expose.getPorts().get(0).getElement().isProtocolProvided());
+
+        assertEquals(" ", expose.getPorts().get(1).getElement().getPrefix().getWhitespace());
+        assertEquals("8081", expose.getPorts().get(1).getElement().getPort());
+        assertEquals("tcp", expose.getPorts().get(1).getElement().getProtocol());
+        assertFalse(expose.getPorts().get(1).getElement().isProtocolProvided());
+        assertEquals(" \\\n", expose.getPorts().get(1).getAfter().getWhitespace());
+
+        assertEquals("", expose.getPorts().get(2).getAfter().getWhitespace());
+        assertEquals("\t\t", expose.getPorts().get(2).getElement().getPrefix().getWhitespace());
+        assertEquals("9999", expose.getPorts().get(2).getElement().getPort());
+        assertEquals("udp", expose.getPorts().get(2).getElement().getProtocol());
+        assertTrue(expose.getPorts().get(2).getElement().isProtocolProvided());
+
+        Docker.Shell shell = (Docker.Shell) stage.getChildren().get(5);
+        assertEquals(Space.EMPTY, shell.getPrefix());
+        assertEquals(2, shell.getCommands().size());
+        assertLiteral(shell.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "powershell", "");
+        assertLiteral(shell.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", " ");
+        assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
+        assertEquals("", shell.getExecFormSuffix().getWhitespace());
+
+        Docker.User user = (Docker.User) stage.getChildren().get(6);
+        assertEquals(Space.EMPTY, user.getPrefix());
+        assertLiteral(user.getUsername(), Quoting.UNQUOTED, " ", "root", "");
+        assertLiteral(user.getGroup(), Quoting.UNQUOTED, "", "admin", "");
+
+        Docker.Volume volume = (Docker.Volume) stage.getChildren().get(7);
+        assertEquals(Space.EMPTY, volume.getPrefix());
+        assertEquals(" ", volume.getExecFormPrefix().getWhitespace());
+        assertEquals("", volume.getExecFormSuffix().getWhitespace());
+        assertEquals(2, volume.getPaths().size());
+        assertLiteral(volume.getPaths().get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "");
+        assertLiteral(volume.getPaths().get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ");
+
+        Docker.Workdir workdir = (Docker.Workdir) stage.getChildren().get(8);
+        assertEquals(Space.EMPTY, workdir.getPrefix());
+        assertLiteral(workdir.getPath(), Quoting.UNQUOTED, " ", "/var/log", "");
+
+        Docker.Label label = (Docker.Label) stage.getChildren().get(9);
+        assertEquals(Space.EMPTY, label.getPrefix());
+        assertEquals(2, label.getArgs().size());
+        assertRightPaddedArg(label.getArgs().get(0), Quoting.UNQUOTED, " ", "foo", true, "bar", "");
+        assertRightPaddedArg(label.getArgs().get(1), Quoting.UNQUOTED, " ", "baz", true, "qux", "");
+
+        Docker.StopSignal stopSignal = (Docker.StopSignal) stage.getChildren().get(10);
+        assertEquals(Space.EMPTY, stopSignal.getPrefix());
+        assertLiteral(stopSignal.getSignal(), Quoting.UNQUOTED, " ", "SIGKILL", "");
+
+        Docker.Healthcheck healthCheck = (Docker.Healthcheck) stage.getChildren().get(11);
+        assertEquals(Space.EMPTY, healthCheck.getPrefix());
+        assertEquals(1, healthCheck.getCommands().size());
+        assertLiteral(healthCheck.getCommands().get(0), Quoting.UNQUOTED, " ", "NONE", "");
+    }
+
+    @Test
+    void handleMultipleNewlinesEOF() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN echo Hello World
+
+
+
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
+        assertEquals(printableWhiteSpace("\n\n\n"), printableWhiteSpace(doc.getEof().getWhitespace()));
+    }
+
+    @Test
+    @SuppressWarnings("TrailingWhitespacesInTextBlock")
+    void handleMultipleCRLFinEOF() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN echo Hello World
+                \r
+                \r
+                \r
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(3, args.size());
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
+        assertEquals(printableWhiteSpace("\r\n\r\n\r\n"), printableWhiteSpace(doc.getEof().getWhitespace()));
+    }
+
+    @Test
+    void handleMultipleStagesWithoutAliasNames() {
+        DockerfileParser parser = new DockerfileParser();
+
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                FROM ubuntu:20.04
+                RUN apt-get update && apt-get install -y build-essential
+                RUN echo "Stage 1 complete" > /stage1.txt
+
+                FROM ubuntu:20.04
+                COPY --from=0 /stage1.txt /stage2.txt
+                RUN echo "Stage 2 complete" > /stage2_complete.txt
+
+                FROM ubuntu:20.04
+                COPY --from=1 /stage2_complete.txt /stage3.txt
+                RUN echo "Stage 3 complete" > /stage3_complete.txt
+
+                FROM ubuntu:20.04
+                COPY --from=2 /stage3_complete.txt /final_stage.txt
+                CMD ["cat", "/final_stage.txt"]
+                """.getBytes(StandardCharsets.UTF_8)));
+
+
+        assertNotNull(doc, "Expected document to be non-null but was null");
+        assertNotNull(doc.getStages(),
+                "Expected document to have stages but was null");
+        assertEquals(4, doc.getStages().size(),
+                "Expected document to have " + 4 + " stage but was " + doc.getStages().size());
+
+        Docker.Stage stage = doc.getStages().get(0);
+        assertNotNull(stage.getChildren(),
+                "Expected stage to have children but was null");
+
+        for (Docker.Stage docStage : doc.getStages()) {
+            assertNotNull(docStage.getChildren(),
+                    "Expected stage to have children but was null");
+            assertEquals(3, docStage.getChildren().size(),
+                    "Expected every stage to have only 3 children but was " + stage.getChildren().size());
+        }
+
+        Docker.Stage stage0 = doc.getStages().get(0);
+        Docker.Stage stage1 = doc.getStages().get(1);
+        Docker.Stage stage2 = doc.getStages().get(2);
+        Docker.Stage finalStage = doc.getStages().get(3);
+
+        Docker.From from = (Docker.From) stage0.getChildren().get(0);
+        assertEquals(Space.EMPTY, from.getPrefix());
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
+        assertEquals("20.04", from.getTag());
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "");
+
+
+        Docker.Run run = (Docker.Run) stage0.getChildren().get(1);
+        assertEquals(Space.EMPTY, run.getPrefix());
+        List<Docker.Literal> commands = run.getCommands();
+        assertEquals(7, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(commands.get(1), Quoting.UNQUOTED, " ", "update", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", "&&", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(commands.get(4), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(commands.get(5), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(commands.get(6), Quoting.UNQUOTED, " ", "build-essential", "");
+
+
+        run = (Docker.Run) stage0.getChildren().get(2);
+        assertEquals(Space.EMPTY, run.getPrefix());
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 1 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage1.txt", "");
+
+
+        Docker.From from1 = (Docker.From) stage1.getChildren().get(0);
+        assertEquals(Space.NEWLINE, from1.getPrefix());
+        assertLiteral(from1.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from1.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
+        assertEquals("20.04", from1.getTag());
+        assertLiteral(from1.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from1.getAlias(), Quoting.UNQUOTED, "", null, "");
+
+        Docker.Copy copy = (Docker.Copy) stage1.getChildren().get(1);
+        assertEquals(Space.EMPTY, copy.getPrefix());
+        List<Docker.Option> opts = copy.getOptions();
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "0");
+
+        List<Docker.Literal> sources = copy.getSources();
+        assertEquals(1, sources.size());
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage1.txt", "");
+        Docker.Literal dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/stage2.txt", "");
+
+        run = (Docker.Run) stage1.getChildren().get(2);
+        assertEquals(Space.EMPTY, run.getPrefix());
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 2 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "");
+
+        Docker.From from2 = (Docker.From) stage2.getChildren().get(0);
+        assertEquals(Space.NEWLINE, from2.getPrefix());
+        assertLiteral(from2.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from2.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
+        assertEquals("20.04", from2.getTag());
+        assertLiteral(from2.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from2.getAlias(), Quoting.UNQUOTED, "", null, "");
+
+        copy = (Docker.Copy) stage2.getChildren().get(1);
+        assertEquals(Space.EMPTY, copy.getPrefix());
+        opts = copy.getOptions();
+        sources = copy.getSources();
+        assertEquals(1, sources.size());
+
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "1");
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "");
+        dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/stage3.txt", "");
+        run = (Docker.Run) stage2.getChildren().get(2);
+        assertEquals(Space.EMPTY, run.getPrefix());
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 3 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "");
+
+        Docker.From from3 = (Docker.From) finalStage.getChildren().get(0);
+        assertEquals(Space.NEWLINE, from3.getPrefix());
+        assertLiteral(from3.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from3.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
+        assertEquals("20.04", from3.getTag());
+        assertLiteral(from3.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from3.getAlias(), Quoting.UNQUOTED, "", null, "");
+
+        copy = (Docker.Copy) finalStage.getChildren().get(1);
+        assertEquals(Space.EMPTY, copy.getPrefix());
+
+        opts = copy.getOptions();
+        sources = copy.getSources();
+        assertEquals(1, sources.size());
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "2");
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "");
+        dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/final_stage.txt", "");
+
+        Docker.Cmd cmd = (Docker.Cmd) finalStage.getChildren().get(2);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+        assertLiteral(cmd.getCommands().get(0), Quoting.DOUBLE_QUOTED, "", "cat", "");
+        assertLiteral(cmd.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "/final_stage.txt", "");
+        assertEquals(" ", cmd.getExecFormPrefix().getWhitespace());
+    }
+
+    @Test
+    void testDockerfileWithCommentBetweenContinuationLines() {
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
+                """
+                RUN echo Hello World \\
+                # This is a comment
+                && echo Goodbye World
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
+
+        Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, cmd.getPrefix());
+
+        List<Docker.Literal> args = cmd.getCommands();
+        assertEquals(11, args.size());
+
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", " \\\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "#", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "This", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "is", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "a", "");
+
+        // TODO: this should be two separate literals
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "comment\n&&", "");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(9), Quoting.UNQUOTED, " ", "Goodbye", "");
+        assertLiteral(args.get(10), Quoting.UNQUOTED, " ", "World", "");
+
+    }
+
+    @Test
+    void testInstructionPrefixWithContinuationCommands() {
+        String monster = """
+        ENV LAST_COMMIT=e2db71ff940a8b8c08c4ae894b952bfe7f0cf309
+
+        RUN set -eux; \\
+        	\\
+        	apk add --no-cache --virtual .build-deps
+        """;
+
+        DockerfileParser parser = new DockerfileParser();
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(monster.getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount(doc, 2);
+        Docker.Env env = (Docker.Env) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, env.getPrefix());
+        assertEquals(1, env.getArgs().size());
+        assertRightPaddedArg(env.getArgs().get(0), Quoting.UNQUOTED, " ", "LAST_COMMIT", true, "e2db71ff940a8b8c08c4ae894b952bfe7f0cf309", "");
+
+        Docker.Run run = (Docker.Run) stage.getChildren().get(1);
+        assertEquals(Space.NEWLINE, run.getPrefix());
+        assertEquals(7, run.getCommands().size());
+        assertLiteral(run.getCommands().get(0), Quoting.UNQUOTED, " ", "set", "");
+        assertLiteral(run.getCommands().get(1), Quoting.UNQUOTED, " ", "-eux;", " \\\n\t\\\n\t");
+        assertLiteral(run.getCommands().get(2), Quoting.UNQUOTED, "", "apk", "");
+        assertLiteral(run.getCommands().get(3), Quoting.UNQUOTED, " ", "add", "");
+        assertLiteral(run.getCommands().get(4), Quoting.UNQUOTED, " ", "--no-cache", "");
+        assertLiteral(run.getCommands().get(5), Quoting.UNQUOTED, " ", "--virtual", "");
+        assertLiteral(run.getCommands().get(6), Quoting.UNQUOTED, " ", ".build-deps", "");
+    }
+}

--- a/src/test/java/org/openrewrite/docker/internal/FullLineIteratorTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/FullLineIteratorTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FullLineIteratorTest {
+
+    private FullLineIterator iterator;
+    private InputStream inputStream;
+
+    @AfterEach
+    void cleanup() {
+        if (iterator != null) {
+            iterator.close();
+        }
+    }
+
+    @Nested
+    class BasicFunctionality {
+        @Test
+        void shouldReadSingleLine() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Hello, world!".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Hello, world!", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldReadMultipleLines() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Line 1\nLine 2\nLine 3".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Line 1", iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals("Line 2", iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals("Line 3", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldHandleEmptyInput() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Nested
+    class EmptyLineHandling {
+        @Test
+        void shouldHandleSingleEmptyLine() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("\n".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertFalse(iterator.hasNext());
+            assertTrue(iterator.hasEol());
+        }
+
+        @Test
+        void shouldHandleMultipleEmptyLines() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("\n\n\n".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldHandleMixedEmptyAndNonEmptyLines() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Line 1\n\nLine 3\n\n".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Line 1", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertTrue(iterator.hasNext());
+            assertEquals("Line 3", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertTrue(iterator.hasNext());
+            assertEquals("", iterator.next());
+            assertTrue(iterator.hasEol());
+
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldHandleLineWithoutNewline() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Line without newline".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Line without newline", iterator.next());
+            assertFalse(iterator.hasEol());
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Nested
+    class EdgeCases {
+        @Test
+        void shouldHandleUnicodeCharacters() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("こんにちは\n你好\nBonjour".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("こんにちは", iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals("你好", iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals("Bonjour", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldHandleCarriageReturnProperly() {
+            // Arrange - CR should be treated as a regular character, not a line delimiter
+            inputStream = new ByteArrayInputStream("Line with\rcarriage return\nNext line".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Line with\rcarriage return", iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals("Next line", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+
+        @Test
+        void shouldHandleCRLFAsRegularCharactersThenNewline() {
+            // Arrange - CRLF should be treated as CR followed by LF, where LF is the delimiter
+            inputStream = new ByteArrayInputStream("Line with\r\nCRLF".getBytes(StandardCharsets.UTF_8));
+
+            // Act
+            iterator = new FullLineIterator(inputStream);
+
+            // Assert
+            assertTrue(iterator.hasNext());
+            assertEquals("Line with\r", iterator.next()); // CR is part of the string, LF is delimiter
+            assertTrue(iterator.hasNext());
+            assertEquals("CRLF", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Nested
+    class ErrorHandling {
+        @Test
+        void shouldThrowWhenUsingInvalidInputStream() {
+            // Arrange
+            InputStream invalidStream = new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    throw new IOException("Test exception");
+                }
+            };
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () -> new FullLineIterator(invalidStream));
+        }
+
+        @Test
+        void shouldCaptureExceptionOnClose() throws IOException {
+            // Arrange
+            InputStream problematicStream = new ByteArrayInputStream("test data".getBytes()) {
+                @Override
+                public void close() throws IOException {
+                    throw new IOException("Error during close");
+                }
+            };
+
+            iterator = new FullLineIterator(problematicStream);
+
+            // Act
+            iterator.close();
+
+            // Assert
+            assertNotNull(iterator.exception());
+            assertEquals("Error during close", iterator.exception().getMessage());
+        }
+
+        @Test
+        void shouldHandleMultipleCloseCalls() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8));
+            iterator = new FullLineIterator(inputStream);
+
+            // Act & Assert - should not throw
+            iterator.close();
+            iterator.close(); // Second call should be safe
+        }
+    }
+
+    @Nested
+    class IteratorBehavior {
+        @Test
+        void shouldIterateThroughAllLines() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Line 1\nLine 2\nLine 3".getBytes(StandardCharsets.UTF_8));
+            iterator = new FullLineIterator(inputStream);
+
+            // Act & Assert
+            int count = 0;
+            while (iterator.hasNext()) {
+                iterator.next();
+                count++;
+            }
+
+            assertEquals(3, count);
+        }
+
+        @Test
+        void shouldTrackEolForEachLine() {
+            // Arrange
+            inputStream = new ByteArrayInputStream("Line 1\nLine 2\nLine 3".getBytes(StandardCharsets.UTF_8));
+            iterator = new FullLineIterator(inputStream);
+
+            // Act & Assert
+            iterator.next();
+            assertTrue(iterator.hasEol());
+
+            iterator.next();
+            assertTrue(iterator.hasEol());
+
+            iterator.next();
+            assertFalse(iterator.hasEol()); // Last line doesn't have EOL
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/docker/internal/FullLineIteratorTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/FullLineIteratorTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
@@ -27,13 +27,13 @@ class StringWithPaddingTest {
 
     static Stream<TestCase> provideTestCases() {
         return Stream.of(
-                new TestCase("  content  ", "content", "  ", "  "),
-                new TestCase("\tcontent\t", "content", "\t", "\t"),
-                new TestCase("content", "content", "", ""),
-                new TestCase("  content", "content", "  ", ""),
-                new TestCase("content  ", "content", "", "  "),
-                new TestCase("", "", "", ""),
-                new TestCase("  ", "", "  ", "")
+          new TestCase("  content  ", "content", "  ", "  "),
+          new TestCase("\tcontent\t", "content", "\t", "\t"),
+          new TestCase("content", "content", "", ""),
+          new TestCase("  content", "content", "  ", ""),
+          new TestCase("content  ", "content", "", "  "),
+          new TestCase("", "", "", ""),
+          new TestCase("  ", "", "  ", "")
         );
     }
 

--- a/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
+++ b/src/test/java/org/openrewrite/docker/internal/StringWithPaddingTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.openrewrite.docker.tree.Space;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringWithPaddingTest {
+
+    static Stream<TestCase> provideTestCases() {
+        return Stream.of(
+                new TestCase("  content  ", "content", "  ", "  "),
+                new TestCase("\tcontent\t", "content", "\t", "\t"),
+                new TestCase("content", "content", "", ""),
+                new TestCase("  content", "content", "  ", ""),
+                new TestCase("content  ", "content", "", "  "),
+                new TestCase("", "", "", ""),
+                new TestCase("  ", "", "  ", "")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    @DisplayName("Test StringWithPadding.of() with various inputs")
+    void testStringWithPadding(TestCase testCase) {
+        StringWithPadding result = StringWithPadding.of(testCase.input);
+
+        assertEquals(testCase.expectedContent, result.content());
+        assertEquals(Space.build(testCase.expectedPrefix), result.prefix());
+        assertEquals(Space.build(testCase.expectedSuffix), result.suffix());
+    }
+
+    static class TestCase {
+        String input;
+        String expectedContent;
+        String expectedPrefix;
+        String expectedSuffix;
+
+        TestCase(String input, String expectedContent, String expectedPrefix, String expectedSuffix) {
+            this.input = input;
+            this.expectedContent = expectedContent;
+            this.expectedPrefix = expectedPrefix;
+            this.expectedSuffix = expectedSuffix;
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
@@ -34,54 +34,54 @@ class DockerLiteralTest implements RewriteTest {
             )
           ),
           dockerfile(
-                    """
-                    # Use a specific base image with Java installed
-                    FROM openjdk:17-jdk-slim
+            """
+            # Use a specific base image with Java installed
+            FROM openjdk:17-jdk-slim
 
-                    # Set environment variables for Java paths
-                    ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-                    ENV PATH=$JAVA_HOME/bin:$PATH
+            # Set environment variables for Java paths
+            ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+            ENV PATH=$JAVA_HOME/bin:$PATH
 
-                    # Example RUN commands using hard-coded Java paths
-                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
-                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
+            # Example RUN commands using hard-coded Java paths
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
 
-                    # Set the working directory
-                    WORKDIR /app
+            # Set the working directory
+            WORKDIR /app
 
-                    # Copy application files into the container
-                    COPY . .
+            # Copy application files into the container
+            COPY . .
 
-                    # Compile the application
-                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
+            # Compile the application
+            RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
 
-                    # Command to run the application
-                    CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
-                    """,
-                  """
-                  # Use a specific base image with Java installed
-                  FROM openjdk:21-jdk-slim
+            # Command to run the application
+            CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
+            """,
+            """
+            # Use a specific base image with Java installed
+            FROM openjdk:21-jdk-slim
 
-                  # Set environment variables for Java paths
-                  ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-                  ENV PATH=$JAVA_HOME/bin:$PATH
+            # Set environment variables for Java paths
+            ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+            ENV PATH=$JAVA_HOME/bin:$PATH
 
-                  # Example RUN commands using hard-coded Java paths
-                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
-                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
+            # Example RUN commands using hard-coded Java paths
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
 
-                  # Set the working directory
-                  WORKDIR /app
+            # Set the working directory
+            WORKDIR /app
 
-                  # Copy application files into the container
-                  COPY . .
+            # Copy application files into the container
+            COPY . .
 
-                  # Compile the application
-                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
+            # Compile the application
+            RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
 
-                  # Command to run the application
-                  CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]
-                  """
+            # Command to run the application
+            CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]
+            """
           )
         );
     }

--- a/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
+++ b/src/test/java/org/openrewrite/docker/trait/DockerLiteralTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Pattern;
+
+import static org.openrewrite.docker.Assertions.dockerfile;
+import static org.openrewrite.docker.trait.Traits.literal;
+
+class DockerLiteralTest implements RewriteTest {
+    @Test
+    void matchAllLiterals() {
+        // TODO: treat key and value in KeyArgs as literals
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+              literal(Pattern.compile(".*(?<=java-)(17)-.*|.*(17)(?=-jdk-slim).*")).asVisitor(lit -> lit.withText(
+                lit.getText().replace("17", "21")
+              ).getTree())
+            )
+          ),
+          dockerfile(
+                    """
+                    # Use a specific base image with Java installed
+                    FROM openjdk:17-jdk-slim
+
+                    # Set environment variables for Java paths
+                    ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+                    ENV PATH=$JAVA_HOME/bin:$PATH
+
+                    # Example RUN commands using hard-coded Java paths
+                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/java -version
+                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac -version
+
+                    # Set the working directory
+                    WORKDIR /app
+
+                    # Copy application files into the container
+                    COPY . .
+
+                    # Compile the application
+                    RUN /usr/lib/jvm/java-17-openjdk-amd64/bin/javac Main.java
+
+                    # Command to run the application
+                    CMD ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "Main"]
+                    """,
+                  """
+                  # Use a specific base image with Java installed
+                  FROM openjdk:21-jdk-slim
+
+                  # Set environment variables for Java paths
+                  ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+                  ENV PATH=$JAVA_HOME/bin:$PATH
+
+                  # Example RUN commands using hard-coded Java paths
+                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/java -version
+                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac -version
+
+                  # Set the working directory
+                  WORKDIR /app
+
+                  # Copy application files into the container
+                  COPY . .
+
+                  # Compile the application
+                  RUN /usr/lib/jvm/java-21-openjdk-amd64/bin/javac Main.java
+
+                  # Command to run the application
+                  CMD ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "Main"]
+                  """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
@@ -28,7 +28,7 @@ class DockerfilePrinterTest {
     @Test
     void visitFrom() {
         Docker.Document doc = Docker.Document.build(
-                Docker.From.build("alpine:latest").withEol(Space.EMPTY)
+          Docker.From.build("alpine:latest").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "FROM alpine:latest";
@@ -38,9 +38,9 @@ class DockerfilePrinterTest {
     @Test
     void visitFromLowercased() {
         Docker.Document doc = Docker.Document.build(
-                Docker.From.build("alpine:latest")
-                        .withEol(Space.EMPTY)
-                        .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "from"))))
+          Docker.From.build("alpine:latest")
+            .withEol(Space.EMPTY)
+            .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "from"))))
         ).withEof(Space.EMPTY);
 
         String expected = "from alpine:latest";
@@ -50,9 +50,9 @@ class DockerfilePrinterTest {
     @Test
     void visitFromIgnoreInvalidInstructionName() {
         Docker.Document doc = Docker.Document.build(
-                Docker.From.build("alpine:latest")
-                        .withEol(Space.EMPTY)
-                        .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "apples"))))
+          Docker.From.build("alpine:latest")
+            .withEol(Space.EMPTY)
+            .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "apples"))))
         ).withEof(Space.EMPTY);
 
         String expected = "FROM alpine:latest";
@@ -62,9 +62,9 @@ class DockerfilePrinterTest {
     @Test
     void visitFromFull() {
         Docker.Document doc = Docker.Document.build(
-                Docker.From.build("alpine:latest")
-                        .alias("build")
-                        .platform("linux/amd64").withEol(Space.EMPTY)
+          Docker.From.build("alpine:latest")
+            .alias("build")
+            .platform("linux/amd64").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "FROM --platform=linux/amd64 alpine:latest AS build";
@@ -74,7 +74,7 @@ class DockerfilePrinterTest {
     @Test
     void visitComment() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Comment.build("This is a comment").withEol(Space.EMPTY)
+          Docker.Comment.build("This is a comment").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "# This is a comment";
@@ -84,7 +84,7 @@ class DockerfilePrinterTest {
     @Test
     void visitMultilineComment() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Comment.build("This is a comment\nwith multiple lines").withEol(Space.EMPTY)
+          Docker.Comment.build("This is a comment\nwith multiple lines").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "# This is a comment\n# with multiple lines";
@@ -94,7 +94,7 @@ class DockerfilePrinterTest {
     @Test
     void visitDirective() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Directive.build("escape", "'").withEol(Space.EMPTY)
+          Docker.Directive.build("escape", "'").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "# escape='";
@@ -104,8 +104,8 @@ class DockerfilePrinterTest {
     @Test
     void visitRun() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Run.build("echo Hello World").withEol(Space.NEWLINE),
-                Docker.Run.build("echo Goodbye World").withEol(Space.EMPTY)
+          Docker.Run.build("echo Hello World").withEol(Space.NEWLINE),
+          Docker.Run.build("echo Goodbye World").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "RUN echo Hello World\nRUN echo Goodbye World";
@@ -115,13 +115,13 @@ class DockerfilePrinterTest {
     @Test
     void visitRunWithLeftAlignedHeredoc() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Run.build("""
-                                 <<EOF
-                                 apt-get update
-                                 apt-get upgrade -y
-                                 apt-get install -y ...
-                                 EOF
-                                 """).withEol(Space.EMPTY)
+          Docker.Run.build("""
+                           <<EOF
+                           apt-get update
+                           apt-get upgrade -y
+                           apt-get install -y ...
+                           EOF
+                           """).withEol(Space.EMPTY)
         );
 
         String expected = """
@@ -137,13 +137,13 @@ class DockerfilePrinterTest {
     @Test
     void visitRunWithIndentedHeredoc() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Run.build("""
-                                 python3 <<EOF
-                                 with open("/hello", "w") as f:
-                                     print("Hello", file=f)
-                                     print("World", file=f)
-                                 EOF
-                                 """).withEol(Space.EMPTY)
+          Docker.Run.build("""
+                           python3 <<EOF
+                           with open("/hello", "w") as f:
+                               print("Hello", file=f)
+                               print("World", file=f)
+                           EOF
+                           """).withEol(Space.EMPTY)
         );
 
         String expected = """
@@ -159,7 +159,7 @@ class DockerfilePrinterTest {
     @Test
     void visitLabelUnquoted() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Label.build("version", "1.0").withEol(Space.EMPTY)
+          Docker.Label.build("version", "1.0").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "LABEL version=1.0";
@@ -169,7 +169,7 @@ class DockerfilePrinterTest {
     @Test
     void visitLabelQuoted() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Label.build("version", "\"1.0\"").withEol(Space.EMPTY)
+          Docker.Label.build("version", "\"1.0\"").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
         String expected = "LABEL version=\"1.0\"";
@@ -179,9 +179,9 @@ class DockerfilePrinterTest {
     @Test
     void visitLabelMixedQuotes() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Label.build("version", "1.0"),
-                Docker.Label.build("author", "\"Jim\""),
-                Docker.Label.build("description", "'A simple Dockerfile'")
+          Docker.Label.build("version", "1.0"),
+          Docker.Label.build("author", "\"Jim\""),
+          Docker.Label.build("description", "'A simple Dockerfile'")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -195,11 +195,11 @@ class DockerfilePrinterTest {
     @Test
     void visitLabelMultiplePerLine() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Label.build(
-                        Docker.KeyArgs.build("version", "1.0"),
-                        Docker.KeyArgs.build("author", "\"Jim\""),
-                        Docker.KeyArgs.build("description", "'A simple Dockerfile'")
-                )
+          Docker.Label.build(
+            Docker.KeyArgs.build("version", "1.0"),
+            Docker.KeyArgs.build("author", "\"Jim\""),
+            Docker.KeyArgs.build("description", "'A simple Dockerfile'")
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -211,7 +211,7 @@ class DockerfilePrinterTest {
     @Test
     void visitMaintainer() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Maintainer.build("Jim S <jim@example.com>")
+          Docker.Maintainer.build("Jim S <jim@example.com>")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -223,7 +223,7 @@ class DockerfilePrinterTest {
     @Test
     void visitExpose() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Expose.build("8080", "8081")
+          Docker.Expose.build("8080", "8081")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -235,7 +235,7 @@ class DockerfilePrinterTest {
     @Test
     void visitExposeWithMixedPortsProvided() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Expose.build("8080", "8081/udp", "8082/tcp")
+          Docker.Expose.build("8080", "8081/udp", "8082/tcp")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -247,8 +247,8 @@ class DockerfilePrinterTest {
     @Test
     void visitEnvMultiline() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Env.build("ENV1", "value1"),
-                Docker.Env.build("ENV2", "value2")
+          Docker.Env.build("ENV1", "value1"),
+          Docker.Env.build("ENV2", "value2")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -261,10 +261,10 @@ class DockerfilePrinterTest {
     @Test
     void visitEnvSingleLine() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Env.build(
-                        Docker.KeyArgs.build("ENV1", "value1"),
-                        Docker.KeyArgs.build("ENV2", "value2")
-                )
+          Docker.Env.build(
+            Docker.KeyArgs.build("ENV1", "value1"),
+            Docker.KeyArgs.build("ENV2", "value2")
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -276,12 +276,12 @@ class DockerfilePrinterTest {
     @Test
     void visitEnvSingleLineDeprecatedSyntaxMixed() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Env.build(
-                        Docker.KeyArgs.build("ENV1", "value1"),
-                        Docker.KeyArgs.build("ENV2", "\"value2\"").withHasEquals(false),
-                        Docker.KeyArgs.build("ENV3", "${ENV1}"),
-                        Docker.KeyArgs.build("ENV4", "${ENV2}").withHasEquals(false)
-                )
+          Docker.Env.build(
+            Docker.KeyArgs.build("ENV1", "value1"),
+            Docker.KeyArgs.build("ENV2", "\"value2\"").withHasEquals(false),
+            Docker.KeyArgs.build("ENV3", "${ENV1}"),
+            Docker.KeyArgs.build("ENV4", "${ENV2}").withHasEquals(false)
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -293,20 +293,20 @@ class DockerfilePrinterTest {
     @Test
     void visitAddComplex() {
         Docker.Document doc = Docker.Document.build(
-                new Docker.Add(
-                        Tree.randomId(),
-                        Space.EMPTY,
-                        List.of(
-                            Docker.Option.build("--keep-git-dir", "false")
-                        ),
-                        List.of(
-                            Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
-                        ),
-                            Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
-                        ),
-                        Markers.EMPTY,
-                        Space.NEWLINE
-                )
+          new Docker.Add(
+            Tree.randomId(),
+            Space.EMPTY,
+            List.of(
+              Docker.Option.build("--keep-git-dir", "false")
+            ),
+            List.of(
+              Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
+            ),
+            Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
+            ),
+            Markers.EMPTY,
+            Space.NEWLINE
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -318,19 +318,19 @@ class DockerfilePrinterTest {
     @Test
     void visitCopy() {
         Docker.Document doc = Docker.Document.build(
-                new Docker.Copy(
-                        Tree.randomId(),
-                        Space.EMPTY,
-                        List.of(
-                            Docker.Option.build("--chown", "user:group")
-                        ),
-                        List.of(
-                            Docker.Literal.build("src").withPrefix(Space.build(" "))
-                        ),
-                        Docker.Literal.build("/dest").withPrefix(Space.build(" ")),
-                        Markers.EMPTY,
-                        Space.NEWLINE
-                )
+          new Docker.Copy(
+            Tree.randomId(),
+            Space.EMPTY,
+            List.of(
+              Docker.Option.build("--chown", "user:group")
+            ),
+            List.of(
+              Docker.Literal.build("src").withPrefix(Space.build(" "))
+            ),
+            Docker.Literal.build("/dest").withPrefix(Space.build(" ")),
+            Markers.EMPTY,
+            Space.NEWLINE
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -342,7 +342,7 @@ class DockerfilePrinterTest {
     @Test
     void visitEntrypointExecForm() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Entrypoint.build("python3", "app.py")
+          Docker.Entrypoint.build("python3", "app.py")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -354,7 +354,7 @@ class DockerfilePrinterTest {
     @Test
     void visitEntrypointShellForm() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Entrypoint.build(Form.SHELL,"exec", "top", "-b")
+          Docker.Entrypoint.build(Form.SHELL, "exec", "top", "-b")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -366,7 +366,7 @@ class DockerfilePrinterTest {
     @Test
     void visitVolumeExec() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Volume.build("/data")
+          Docker.Volume.build("/data")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -378,7 +378,7 @@ class DockerfilePrinterTest {
     @Test
     void visitVolumeShell() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Volume.build(Form.SHELL, "/data")
+          Docker.Volume.build(Form.SHELL, "/data")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -390,7 +390,7 @@ class DockerfilePrinterTest {
     @Test
     void visitUserSimple() {
         Docker.Document doc = Docker.Document.build(
-                Docker.User.build("user")
+          Docker.User.build("user")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -402,7 +402,7 @@ class DockerfilePrinterTest {
     @Test
     void visitWorkDir() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Workdir.build("/app")
+          Docker.Workdir.build("/app")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -414,9 +414,9 @@ class DockerfilePrinterTest {
     @Test
     void visitOnBuild() {
         Docker.Document doc = Docker.Document.build(
-                Docker.OnBuild.build(
-                        Docker.Run.build("echo Hello World").withEol(Space.EMPTY)
-                )
+          Docker.OnBuild.build(
+            Docker.Run.build("echo Hello World").withEol(Space.EMPTY)
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -428,7 +428,7 @@ class DockerfilePrinterTest {
     @Test
     void visitStopSignal() {
         Docker.Document doc = Docker.Document.build(
-                Docker.StopSignal.build("SIGTERM")
+          Docker.StopSignal.build("SIGTERM")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -440,7 +440,7 @@ class DockerfilePrinterTest {
     @Test
     void visitStopSignalNumerical() {
         Docker.Document doc = Docker.Document.build(
-                Docker.StopSignal.build("15")
+          Docker.StopSignal.build("15")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -453,27 +453,27 @@ class DockerfilePrinterTest {
     void visitHealthCheck() {
         Docker.Document doc = Docker.Document.build(
 
-                new Docker.Healthcheck(
-                        Tree.randomId(),
-                        Space.EMPTY,
-                        Docker.Healthcheck.Type.CMD,
-                        List.of(
-                                DockerRightPadded.build(
-                                    Docker.KeyArgs.build("--interval", "30s")
-                                ),
-                                DockerRightPadded.build(
-                                    Docker.KeyArgs.build("--timeout", "10s")
-                                ),
-                                DockerRightPadded.build(
-                                    Docker.KeyArgs.build("--retries", "3")
-                                )
-                        ),
-                        List.of(
-                            Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
-                        ),
-                        Markers.EMPTY,
-                        Space.NEWLINE
-                )
+          new Docker.Healthcheck(
+            Tree.randomId(),
+            Space.EMPTY,
+            Docker.Healthcheck.Type.CMD,
+            List.of(
+              DockerRightPadded.build(
+                Docker.KeyArgs.build("--interval", "30s")
+              ),
+              DockerRightPadded.build(
+                Docker.KeyArgs.build("--timeout", "10s")
+              ),
+              DockerRightPadded.build(
+                Docker.KeyArgs.build("--retries", "3")
+              )
+            ),
+            List.of(
+              Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
+            ),
+            Markers.EMPTY,
+            Space.NEWLINE
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -485,15 +485,15 @@ class DockerfilePrinterTest {
     @Test
     void visitHealthCheckNone() {
         Docker.Document doc = Docker.Document.build(
-                new Docker.Healthcheck(
-                        Tree.randomId(),
-                        Space.EMPTY,
-                        Docker.Healthcheck.Type.NONE,
-                        List.of(),
-                        List.of(),
-                        Markers.EMPTY,
-                        Space.NEWLINE
-                )
+          new Docker.Healthcheck(
+            Tree.randomId(),
+            Space.EMPTY,
+            Docker.Healthcheck.Type.NONE,
+            List.of(),
+            List.of(),
+            Markers.EMPTY,
+            Space.NEWLINE
+          )
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -505,7 +505,7 @@ class DockerfilePrinterTest {
     @Test
     void visitShell() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Shell.build("sh", "-c").withEol(Space.NEWLINE)
+          Docker.Shell.build("sh", "-c").withEol(Space.NEWLINE)
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -517,7 +517,7 @@ class DockerfilePrinterTest {
     @Test
     void visitCmdShellForm() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Cmd.build(Form.SHELL, "echo Hello World")
+          Docker.Cmd.build(Form.SHELL, "echo Hello World")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -529,7 +529,7 @@ class DockerfilePrinterTest {
     @Test
     void visitCmdExecForm() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Cmd.build(Form.EXEC, "echo", "Hello World")
+          Docker.Cmd.build(Form.EXEC, "echo", "Hello World")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -541,7 +541,7 @@ class DockerfilePrinterTest {
     @Test
     void visitArg() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Arg.build("MY_ARG", "default_value")
+          Docker.Arg.build("MY_ARG", "default_value")
         ).withEof(Space.EMPTY);
 
         String expected = """
@@ -553,7 +553,7 @@ class DockerfilePrinterTest {
     @Test
     void visitArgNoValue() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Arg.build("MY_ARG", null)
+          Docker.Arg.build("MY_ARG", null)
         ).withEof(Space.EMPTY);
 
         String expected = """

--- a/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 Jim Schubert
+ * Copyright 2022 the original author or authors.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/org/openrewrite/docker/tree/DockerfilePrinterTest.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2025 Jim Schubert
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DockerfilePrinterTest {
+
+    @Test
+    void visitFrom() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.From.build("alpine:latest").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "FROM alpine:latest";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitFromLowercased() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.From.build("alpine:latest")
+                        .withEol(Space.EMPTY)
+                        .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "from"))))
+        ).withEof(Space.EMPTY);
+
+        String expected = "from alpine:latest";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitFromIgnoreInvalidInstructionName() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.From.build("alpine:latest")
+                        .withEol(Space.EMPTY)
+                        .withMarkers(Markers.build(List.of(new InstructionName(Tree.randomId(), "apples"))))
+        ).withEof(Space.EMPTY);
+
+        String expected = "FROM alpine:latest";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitFromFull() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.From.build("alpine:latest")
+                        .alias("build")
+                        .platform("linux/amd64").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "FROM --platform=linux/amd64 alpine:latest AS build";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitComment() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Comment.build("This is a comment").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "# This is a comment";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitMultilineComment() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Comment.build("This is a comment\nwith multiple lines").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "# This is a comment\n# with multiple lines";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitDirective() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Directive.build("escape", "'").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "# escape='";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitRun() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Run.build("echo Hello World").withEol(Space.NEWLINE),
+                Docker.Run.build("echo Goodbye World").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "RUN echo Hello World\nRUN echo Goodbye World";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitRunWithLeftAlignedHeredoc() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Run.build("""
+                                 <<EOF
+                                 apt-get update
+                                 apt-get upgrade -y
+                                 apt-get install -y ...
+                                 EOF
+                                 """).withEol(Space.EMPTY)
+        );
+
+        String expected = """
+                          RUN <<EOF
+                          apt-get update
+                          apt-get upgrade -y
+                          apt-get install -y ...
+                          EOF
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitRunWithIndentedHeredoc() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Run.build("""
+                                 python3 <<EOF
+                                 with open("/hello", "w") as f:
+                                     print("Hello", file=f)
+                                     print("World", file=f)
+                                 EOF
+                                 """).withEol(Space.EMPTY)
+        );
+
+        String expected = """
+                          RUN python3 <<EOF
+                          with open("/hello", "w") as f:
+                              print("Hello", file=f)
+                              print("World", file=f)
+                          EOF
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitLabelUnquoted() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Label.build("version", "1.0").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "LABEL version=1.0";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitLabelQuoted() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Label.build("version", "\"1.0\"").withEol(Space.EMPTY)
+        ).withEof(Space.EMPTY);
+
+        String expected = "LABEL version=\"1.0\"";
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitLabelMixedQuotes() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Label.build("version", "1.0"),
+                Docker.Label.build("author", "\"Jim\""),
+                Docker.Label.build("description", "'A simple Dockerfile'")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          LABEL version=1.0
+                          LABEL author="Jim"
+                          LABEL description='A simple Dockerfile'
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitLabelMultiplePerLine() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Label.build(
+                        Docker.KeyArgs.build("version", "1.0"),
+                        Docker.KeyArgs.build("author", "\"Jim\""),
+                        Docker.KeyArgs.build("description", "'A simple Dockerfile'")
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          LABEL version=1.0 author="Jim" description='A simple Dockerfile'
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitMaintainer() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Maintainer.build("Jim S <jim@example.com>")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          MAINTAINER Jim S <jim@example.com>
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitExpose() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Expose.build("8080", "8081")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          EXPOSE 8080 8081
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitExposeWithMixedPortsProvided() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Expose.build("8080", "8081/udp", "8082/tcp")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          EXPOSE 8080 8081/udp 8082/tcp
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitEnvMultiline() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Env.build("ENV1", "value1"),
+                Docker.Env.build("ENV2", "value2")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ENV ENV1=value1
+                          ENV ENV2=value2
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitEnvSingleLine() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Env.build(
+                        Docker.KeyArgs.build("ENV1", "value1"),
+                        Docker.KeyArgs.build("ENV2", "value2")
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ENV ENV1=value1 ENV2=value2
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitEnvSingleLineDeprecatedSyntaxMixed() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Env.build(
+                        Docker.KeyArgs.build("ENV1", "value1"),
+                        Docker.KeyArgs.build("ENV2", "\"value2\"").withHasEquals(false),
+                        Docker.KeyArgs.build("ENV3", "${ENV1}"),
+                        Docker.KeyArgs.build("ENV4", "${ENV2}").withHasEquals(false)
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ENV ENV1=value1 ENV2 "value2" ENV3=${ENV1} ENV4 ${ENV2}
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitAddComplex() {
+        Docker.Document doc = Docker.Document.build(
+                new Docker.Add(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        List.of(
+                            Docker.Option.build("--keep-git-dir", "false")
+                        ),
+                        List.of(
+                            Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
+                        ),
+                            Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
+                        ),
+                        Markers.EMPTY,
+                        Space.NEWLINE
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ADD --keep-git-dir=false https://example.com/archive.zip /usr/src/things/
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitCopy() {
+        Docker.Document doc = Docker.Document.build(
+                new Docker.Copy(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        List.of(
+                            Docker.Option.build("--chown", "user:group")
+                        ),
+                        List.of(
+                            Docker.Literal.build("src").withPrefix(Space.build(" "))
+                        ),
+                        Docker.Literal.build("/dest").withPrefix(Space.build(" ")),
+                        Markers.EMPTY,
+                        Space.NEWLINE
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          COPY --chown=user:group src /dest
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitEntrypointExecForm() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Entrypoint.build("python3", "app.py")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ENTRYPOINT ["python3","app.py"]
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitEntrypointShellForm() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Entrypoint.build(Form.SHELL,"exec", "top", "-b")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ENTRYPOINT exec top -b
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitVolumeExec() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Volume.build("/data")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          VOLUME ["/data"]
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitVolumeShell() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Volume.build(Form.SHELL, "/data")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          VOLUME /data
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitUserSimple() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.User.build("user")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          USER user
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitWorkDir() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Workdir.build("/app")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          WORKDIR /app
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitOnBuild() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.OnBuild.build(
+                        Docker.Run.build("echo Hello World").withEol(Space.EMPTY)
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ONBUILD RUN echo Hello World
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitStopSignal() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.StopSignal.build("SIGTERM")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          STOPSIGNAL SIGTERM
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitStopSignalNumerical() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.StopSignal.build("15")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          STOPSIGNAL 15
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitHealthCheck() {
+        Docker.Document doc = Docker.Document.build(
+
+                new Docker.Healthcheck(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Docker.Healthcheck.Type.CMD,
+                        List.of(
+                                DockerRightPadded.build(
+                                    Docker.KeyArgs.build("--interval", "30s")
+                                ),
+                                DockerRightPadded.build(
+                                    Docker.KeyArgs.build("--timeout", "10s")
+                                ),
+                                DockerRightPadded.build(
+                                    Docker.KeyArgs.build("--retries", "3")
+                                )
+                        ),
+                        List.of(
+                            Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
+                        ),
+                        Markers.EMPTY,
+                        Space.NEWLINE
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost/ || exit 1
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitHealthCheckNone() {
+        Docker.Document doc = Docker.Document.build(
+                new Docker.Healthcheck(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Docker.Healthcheck.Type.NONE,
+                        List.of(),
+                        List.of(),
+                        Markers.EMPTY,
+                        Space.NEWLINE
+                )
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          HEALTHCHECK NONE
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitShell() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Shell.build("sh", "-c").withEol(Space.NEWLINE)
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          SHELL ["sh","-c"]
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitCmdShellForm() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Cmd.build(Form.SHELL, "echo Hello World")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          CMD echo Hello World
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitCmdExecForm() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Cmd.build(Form.EXEC, "echo", "Hello World")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          CMD ["echo","Hello World"]
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitArg() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Arg.build("MY_ARG", "default_value")
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ARG MY_ARG=default_value
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+
+    @Test
+    void visitArgNoValue() {
+        Docker.Document doc = Docker.Document.build(
+                Docker.Arg.build("MY_ARG", null)
+        ).withEof(Space.EMPTY);
+
+        String expected = """
+                          ARG MY_ARG
+                          """;
+        assertEquals(expected, doc.print(new Cursor(null, new DockerfilePrinter<Integer>())));
+    }
+}


### PR DESCRIPTION
## What's changed?

I'm submitting my docker implementation from [jimschubert/rewrite-docker](https://github.com/jimschubert/rewrite-docker) for your consideration to include in the official rewrite-docker repository.

Tim suggested on social media that I create an issue to discuss collaboration on the rewrite-docker implementation of mine - [jimschubert/rewrite-docker](https://github.com/jimschubert/rewrite-docker). I opened an issue to start that discussion: (https://github.com/openrewrite/rewrite/issues/5653).

There is a lot included in this PR, and is probably best to pull it locally to evaluate. I wrote the parser by hand after a couple failed attempts at trying my hand at an ANTLR implementation. I don't consider myself a parsing guru, but I've just checked [buildkit's parser](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/parser/parser.go) and it looks similar and should be easy for the community to port any gaps.


## What's your motivation?

I had started my implementation in April 2024. Earlier this year, I spent a little time on it to "get it ready" for open sourcing. Around that time I noticed this repo. I think it would be good to contribute my implementation, if considered useful, for the community.

## Anything in particular you'd like reviewers to focus on?

* How would I update the license headers? I tried running `license` and `licenseFormat` tasks, but they didn't modify any files.
* Should I add an Incubating annotation to the parser, or any other classes?
*  The existing `org.openrewrite.docker.search.FindDockerImageUses` does much the same as the `org.openrewrite.docker.analysis.ListImages` I introduce here; should I remove ListImages?
* The traits I've added (e.g. `org.openrewrite.docker.trait.DockerLiteral` were patterned off the traits in the rewrite-java and rewrite-yaml packages. The existing traits in this repo implement `Reference`. Is this preferred? Should I update these, and should I add the preexisting traits to the `org.openrewrite.docker.trait.Traits` class as statics?

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @sambsnyd @shanman190

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

I might be slow to implement any suggestions. I am only finding a couple hours of free time for coding outside of work these days.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
