### PR TITLE
Add handling for single quoted string literals

### DIFF
--- a/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
+++ b/src/main/java/org/openrewrite/docker/trait/DockerfileImageReference.java
@@ -60,7 +60,7 @@ public class DockerfileImageReference implements Reference {
             Cursor c = new Cursor(new Cursor(null, Cursor.ROOT_VALUE), sourceFile);
             String[] words = ((PlainText) sourceFile).getText()
                     .replaceAll("\\s*#.*?\\n", " ") // remove comments
-                    .replaceAll("\".*?\"", " ") // remove string literals
+                    .replaceAll("[\"'].*?[\"']", " ") // remove string literals
                     .split("\\s+");
 
             Set<Reference> references = new HashSet<>();


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Changed regex to support both double-quoted and single-quoted string literals.

## What's your motivation?
Resolves an issue from upgrading base image in internal Dockerfiles.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
